### PR TITLE
Clean up listChecked property in toggleListByPath

### DIFF
--- a/packages/list/src/lib/transforms/toggleListByPath.ts
+++ b/packages/list/src/lib/transforms/toggleListByPath.ts
@@ -5,18 +5,33 @@ export const toggleListByPath = (
   [node, path]: NodeEntry,
   listStyleType: string
 ) => {
-  editor.tf.setNodes(
-    {
-      [KEYS.indent]: node.indent ?? 1,
-      // TODO: normalized if not todo remove this property.
-      [KEYS.listChecked]: false,
-      [KEYS.listType]: listStyleType,
-      type: KEYS.p,
-    },
-    {
-      at: path,
+  editor.tf.withoutNormalizing(() => {
+    if (listStyleType === 'todo') {
+      editor.tf.setNodes(
+        {
+          [KEYS.indent]: node.indent ?? 1,
+          [KEYS.listChecked]: false,
+          [KEYS.listType]: listStyleType,
+          type: KEYS.p,
+        },
+        {
+          at: path,
+        }
+      );
+    } else {
+      editor.tf.unsetNodes([KEYS.listChecked], { at: path });
+      editor.tf.setNodes(
+        {
+          [KEYS.indent]: node.indent ?? 1,
+          [KEYS.listType]: listStyleType,
+          type: KEYS.p,
+        },
+        {
+          at: path,
+        }
+      );
     }
-  );
+  });
 };
 
 export const toggleListByPathUnSet = (


### PR DESCRIPTION
Implemented logic to clean up `listChecked` property when toggling list types. Specifically, `listChecked` is removed if the target list type is not 'todo', and initialized to `false` if it is 'todo'. This addresses the TODO comment in `packages/list/src/lib/transforms/toggleListByPath.ts`.

---
*PR created automatically by Jules for task [11328102442273362159](https://jules.google.com/task/11328102442273362159) started by @arthrod*

## Summary by Sourcery

Normalize list item state when toggling list types to ensure the listChecked property is only present for todo lists.

Bug Fixes:
- Remove stale listChecked state when converting from todo lists to non-todo lists so items no longer retain an inappropriate checked flag.

Enhancements:
- Initialize listChecked to false when toggling into todo list type to ensure a consistent initial state for todo items.