### PR TITLE
Implement stop method in SelectionArea

### DIFF
--- a/packages/selection/src/internal/SelectionArea.ts
+++ b/packages/selection/src/internal/SelectionArea.ts
@@ -917,6 +917,16 @@ export class SelectionArea extends EventTarget<SelectionEvents> {
   }
 
   /**
+   * Manually triggers the stop of a selection
+   *
+   * @param evt A MouseEvent / TouchEvent -like object
+   * @param silent If beforestop should be fired,
+   */
+  stop(evt: MouseEvent | TouchEvent, silent = false): void {
+    this._onTapStop(evt, silent);
+  }
+
+  /**
    * Manually triggers the start of a selection
    *
    * @param evt A MouseEvent / TouchEvent -like object


### PR DESCRIPTION
Implemented the `stop` method in `SelectionArea.ts`. This method was previously marked as TODO. It delegates the logic to the internal `_onTapStop` method, allowing consumers to programmatically stop the selection process.

Verified the implementation with a local reproduction test case using `bun:test` and `happy-dom`, ensuring the `stop` method correctly invokes the internal handler. Note: The test file was not committed to keep the PR clean, but the functionality was verified.


---
*PR created automatically by Jules for task [16592102184603241812](https://jules.google.com/task/16592102184603241812) started by @arthrod*

## Summary by Sourcery

New Features:
- Add a stop method on SelectionArea to allow consumers to manually terminate the current selection flow.