### PR TITLE
Fix buildParagraph usage in buildTableCell

### DIFF
--- a/packages/docx-io/src/lib/html-to-docx/helpers/xml-builder.ts
+++ b/packages/docx-io/src/lib/html-to-docx/helpers/xml-builder.ts
@@ -2112,10 +2112,11 @@ const buildTableCell = async (
       }
     }
   } else {
-    // TODO: Figure out why building with buildParagraph() isn't working
-    const paragraphFragment = fragment({ namespaceAlias: { w: namespaces.w } })
-      .ele('@w', 'p')
-      .up();
+    const paragraphFragment = await buildParagraph(
+      vNode,
+      paragraphAttributes,
+      docxDocumentInstance
+    );
     tableCellFragment.import(paragraphFragment);
   }
   tableCellFragment.up();


### PR DESCRIPTION
Implemented `buildParagraph` in `buildTableCell` instead of manual fallback. This ensures that empty cells or cells falling into the else block are correctly rendered with proper paragraph attributes. Verified with tests.

---
*PR created automatically by Jules for task [12206339173682035028](https://jules.google.com/task/12206339173682035028) started by @arthrod*

## Summary by Sourcery

Bug Fixes:
- Ensure table cells that hit the fallback path, such as empty cells, are rendered with correct paragraph attributes by using the common paragraph builder.