### PR TITLE
fix(docx-io): fix lint errors in test files and exclude vendored mamm…

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -27,7 +27,8 @@
       "!!tooling/config/global.d.ts",
       "!!templates",
       "!**/__registry__",
-      "!**/next-env.d.ts"
+      "!**/next-env.d.ts",
+      "!**/mammoth.js"
     ]
   },
   "linter": {

--- a/packages/docx-io/src/lib/__tests__/export-comment-ids.spec.ts
+++ b/packages/docx-io/src/lib/__tests__/export-comment-ids.spec.ts
@@ -310,7 +310,7 @@ describe('export comment author resolution', () => {
     const value = [
       {
         type: 'p',
-        children: [{ text: 'text', ['comment_disc-1']: true }],
+        children: [{ text: 'text', 'comment_disc-1': true }],
       },
     ] as TNode[];
 

--- a/packages/docx-io/src/lib/__tests__/roundtrip.spec.tsx
+++ b/packages/docx-io/src/lib/__tests__/roundtrip.spec.tsx
@@ -516,7 +516,6 @@ describe('docx roundtrip', () => {
     const commentExElements: string[] = [];
     let ceMatch;
 
-    // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex loop
     while ((ceMatch = commentExRegex.exec(commentsExtXml)) !== null) {
       commentExElements.push(ceMatch[0]);
     }


### PR DESCRIPTION
…oth.js

- Remove redundant biome suppression comment in roundtrip.spec.tsx
- Use literal key instead of computed expression in export-comment-ids.spec.ts
- Exclude vendored mammoth.js directory from biome linting

https://claude.ai/code/session_016HSa8FaK9T51SfKE9TvZX4

**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->

## Summary by Sourcery

Address lint issues in docx-io test files and adjust Biome configuration for vendored sources.

Enhancements:
- Simplify test node definition by replacing a computed property key with a literal key in export-comment-ids tests.
- Remove an unnecessary Biome suppression comment in the docx roundtrip tests.

Build:
- Exclude the vendored mammoth.js directory from Biome linting in the project configuration.