### PR TITLE
fix: normalize VNode properties before iterating to prevent null Type…

### DIFF
--- a/packages/docx-io/src/lib/html-to-docx/vdom/index.ts
+++ b/packages/docx-io/src/lib/html-to-docx/vdom/index.ts
@@ -58,8 +58,9 @@ export class VNode {
     key?: string | null,
     namespace?: string | null
   ) {
+    const props = properties ?? {};
     this.tagName = tagName;
-    this.properties = properties || {};
+    this.properties = props;
     this.children = children || [];
     this.key = key != null ? String(key) : undefined;
     this.namespace = typeof namespace === 'string' ? namespace : null;
@@ -73,9 +74,9 @@ export class VNode {
     let descendantHooks = false;
     let hooks: Record<string, unknown> | undefined;
 
-    for (const propName in properties) {
-      if (Object.hasOwn(properties, propName)) {
-        const property = properties[propName];
+    for (const propName in props) {
+      if (Object.hasOwn(props, propName)) {
+        const property = props[propName];
 
         if (isVHook(property) && (property as Record<string, unknown>).unhook) {
           if (!hooks) {


### PR DESCRIPTION
…Error

The VNode constructor iterates over the raw `properties` parameter with for...in and Object.hasOwn, but `properties` can be null (e.g., when called as `new VNode('p', null, ...)`). Normalize to a local `props` variable using nullish coalescing before any iteration.

https://claude.ai/code/session_01BdcbHWE8hbQPoaoq6XGW9a

**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->

## Summary by Sourcery

Bug Fixes:
- Prevent TypeError in VNode constructor by handling null properties before iterating over them.