### PR TITLE
Fix markdown serialization for resourceLink option with bare autolinks

### DIFF
--- a/.changeset/sharp-autolinks-respect-resource-links.md
+++ b/.changeset/sharp-autolinks-respect-resource-links.md
@@ -1,5 +1,0 @@
----
-"@platejs/markdown": patch
----
-
-Respect `resourceLink` when serializing bare autolink literals

--- a/.changeset/sharp-autolinks-respect-resource-links.md
+++ b/.changeset/sharp-autolinks-respect-resource-links.md
@@ -1,0 +1,5 @@
+---
+"@platejs/markdown": patch
+---
+
+Respect `resourceLink` when serializing bare autolink literals

--- a/.changeset/slate.md
+++ b/.changeset/slate.md
@@ -1,0 +1,5 @@
+---
+"@platejs/slate": patch
+---
+
+Updated `slate-react`.

--- a/docs/solutions/logic-errors/2026-04-03-gfm-extension-fallbacks-must-preserve-user-visible-syntax.md
+++ b/docs/solutions/logic-errors/2026-04-03-gfm-extension-fallbacks-must-preserve-user-visible-syntax.md
@@ -1,19 +1,22 @@
 ---
 module: Markdown
 date: 2026-04-03
+last_updated: 2026-05-11
 problem_type: logic_error
 component: markdown_serializer
 symptoms:
   - "Bare URL links serialized as bracket links instead of staying plain URLs."
+  - "Bare URL links ignored `remarkStringifyOptions.resourceLink = true`."
   - "Footnote references disappeared during markdown deserialization."
   - "Unsupported GFM constructs silently lost the user-visible syntax even when the text itself still mattered."
 root_cause: logic_error
-resolution_type: code_change
+resolution_type: code_fix
 severity: medium
 tags:
   - markdown
   - gfm
   - autolink
+  - resource-link
   - footnote
   - serializer
   - fallback
@@ -44,9 +47,17 @@ model yet, it still has to preserve the syntax users actually typed.
 ### Autolink literal
 
 When a link node is just a plain URL with identical text and href, serialize it
-as raw markdown text instead of a normal link node:
+as raw markdown text instead of a normal link node, unless the caller explicitly
+forces resource links:
 
 ```ts
+const isBareAutolinkLiteral =
+  children.length === 1 &&
+  children[0]?.type === 'text' &&
+  children[0].value === node.url &&
+  options.remarkStringifyOptions?.resourceLink !== true &&
+  BARE_AUTOLINK_PROTOCOL_REGEX.test(node.url ?? '');
+
 if (isBareAutolinkLiteral) {
   return {
     type: 'html',
@@ -62,6 +73,13 @@ https://platejs.org
 ```
 
 instead of degrading to:
+
+```md
+[https://platejs.org](https://platejs.org)
+```
+
+But when the caller sets `remarkStringifyOptions.resourceLink = true`, return
+the normal mdast `link` node and let `remark-stringify` emit:
 
 ```md
 [https://platejs.org](https://platejs.org)
@@ -96,16 +114,24 @@ If full support is not there yet, fallback still needs to preserve what the
 user sees and typed. Losing the marker or rewriting a URL into a different link
 form is data drift, not a harmless implementation detail.
 
+Serializer fallbacks also have to stay below caller-controlled stringify
+options. If an option like `resourceLink` exists specifically to force a
+markdown wire shape, the Plate shortcut should yield the normal mdast node and
+let `remark-stringify` honor that setting.
+
 ## Prevention
 
 - For every unsupported or partially supported markdown extension, define an
   explicit fallback contract.
 - Fallback contracts should preserve user-visible syntax before they preserve
   internal shape convenience.
+- Before returning raw markdown/html from a serializer shortcut, check whether
+  `remarkStringifyOptions` already exposes the caller's requested wire shape.
 - Add package-surface tests for:
   - parse
   - serialize
   - deserialize after serialize
+  - explicit `remarkStringifyOptions` overrides for the same surface
 - Do not accept "the text is still there somewhere" as good enough when the
   syntax itself carries meaning.
 
@@ -115,5 +141,15 @@ These checks passed:
 
 ```bash
 bun test packages/markdown/src/lib/gfmSurface.spec.ts packages/markdown/src/lib/commonmarkSurface.spec.ts packages/markdown/src/lib/defaultRules.spec.ts apps/www/src/__tests__/package-integration/markdown-rich/defaultRule.spec.ts packages/link/src/lib/withLink.spec.tsx
+pnpm lint:fix
+```
+
+Additional resource-link regression:
+
+```bash
+pnpm exec bun test packages/markdown/src/lib/gfmSurface.spec.ts
+pnpm turbo build --filter=./packages/markdown
+pnpm build
+pnpm turbo typecheck --filter=./packages/markdown
 pnpm lint:fix
 ```

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @platejs/ai
 
+## 53.0.4
+
+### Patch Changes
+
+- Updated `@platejs/markdown`.
+
 ## 53.0.3
 
 ### Patch Changes

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platejs/ai",
-  "version": "53.0.3",
+  "version": "53.0.4",
   "description": "Text AI plugin for Plate",
   "keywords": [
     "plate",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,7 @@
     "slate": "0.124.1",
     "slate-dom": "0.124.1",
     "slate-hyperscript": "0.100.0",
-    "slate-react": "0.124.0",
+    "slate-react": "0.124.2",
     "use-deep-compare": "^1.3.0",
     "zustand": "^5.0.5",
     "zustand-x": "6.2.1"

--- a/packages/markdown/CHANGELOG.md
+++ b/packages/markdown/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @platejs/markdown
 
+## 53.0.4
+
+### Patch Changes
+
+- [#4972](https://github.com/udecode/plate/pull/4972) by [@ajmnz](https://github.com/ajmnz) – Respect `resourceLink` when serializing bare autolink literals
+
 ## 53.0.0
 
 ### Major Changes

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platejs/markdown",
-  "version": "53.0.0",
+  "version": "53.0.4",
   "description": "Markdown serializer plugin for Plate",
   "keywords": [
     "markdown",

--- a/packages/markdown/src/lib/gfmSurface.spec.ts
+++ b/packages/markdown/src/lib/gfmSurface.spec.ts
@@ -53,6 +53,29 @@ describe('gfm package surfaces', () => {
     expect(deserializeMd(editor, markdown)).toMatchObject(value);
   });
 
+  it('respects resourceLink when serializing bare autolink literals', () => {
+    const editor = createTestEditor();
+    const value = [
+      {
+        children: [
+          {
+            children: [{ text: 'https://platejs.org' }],
+            type: 'a',
+            url: 'https://platejs.org',
+          },
+        ],
+        type: 'p',
+      },
+    ];
+
+    expect(
+      serializeMd(editor, {
+        remarkStringifyOptions: { resourceLink: true },
+        value: value as any,
+      })
+    ).toBe('[https://platejs.org](https://platejs.org)\n');
+  });
+
   it('round-trips footnote references and definitions as dedicated nodes', () => {
     const editor = createTestEditor();
     const input = '[^1]\n\n[^1]: Footnote text';

--- a/packages/markdown/src/lib/rules/defaultRules.ts
+++ b/packages/markdown/src/lib/rules/defaultRules.ts
@@ -152,6 +152,7 @@ export const defaultRules: MdRules = {
         children.length === 1 &&
         children[0]?.type === 'text' &&
         children[0].value === node.url &&
+        options.remarkStringifyOptions?.resourceLink !== true &&
         BARE_AUTOLINK_PROTOCOL_REGEX.test(node.url ?? '');
 
       if (isBareAutolinkLiteral) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,7 +211,7 @@ importers:
         version: 6.0.1
       slate-test-utils:
         specifier: 1.3.2
-        version: 1.3.2(@testing-library/jest-dom@6.6.3)(@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-react@0.124.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
+        version: 1.3.2(@testing-library/jest-dom@6.6.3)(@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-react@0.124.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
       tailwind-merge:
         specifier: 3.3.1
         version: 3.3.1
@@ -484,7 +484,7 @@ importers:
         version: 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@slate-yjs/react':
         specifier: 1.1.0
-        version: 1.1.0(@slate-yjs/core@1.0.2(slate@0.124.1)(yjs@13.6.29))(react@19.2.4)(slate-react@0.124.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)(yjs@13.6.29)
+        version: 1.1.0(@slate-yjs/core@1.0.2(slate@0.124.1)(yjs@13.6.29))(react@19.2.4)(slate-react@0.124.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)(yjs@13.6.29)
       '@tabler/icons-react':
         specifier: 3.34.0
         version: 3.34.0(react@19.2.4)
@@ -1015,8 +1015,8 @@ importers:
         specifier: 0.100.0
         version: 0.100.0(slate@0.124.1)
       slate-react:
-        specifier: 0.124.0
-        version: 0.124.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
+        specifier: 0.124.2
+        version: 0.124.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
       use-deep-compare:
         specifier: ^1.3.0
         version: 1.3.0(react@19.2.4)
@@ -5653,7 +5653,6 @@ packages:
 
   bun@1.3.9:
     resolution: {integrity: sha512-v5hkh1us7sMNjfimWE70flYbD5I1/qWQaqmJ45q2qk5H/7muQVa478LSVRSFyGTBUBog2LsPQnfIRdjyWJRY+A==}
-    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -9508,8 +9507,8 @@ packages:
     peerDependencies:
       slate: '>=0.65.3'
 
-  slate-react@0.124.0:
-    resolution: {integrity: sha512-NLN6ME64ChOgJtiVTKwISS1sI/Y8/qN1cwmDTZM9AQJCl+jR3XNCvDsKNrW0kJU+1G3NgIGaYoVWhgIVEIL+Aw==}
+  slate-react@0.124.2:
+    resolution: {integrity: sha512-2B6ZZX5qKYeISNaQ9cDuvvp0tWydnHUPuGxyVJZfjD+W00X34dGaAF/5ZyVMZt/O//sf0Glbgd7+NBHRWjiA7Q==}
     peerDependencies:
       react: '>=18.2.0'
       react-dom: '>=18.2.0'
@@ -13567,12 +13566,12 @@ snapshots:
       y-protocols: 1.0.7(yjs@13.6.29)
       yjs: 13.6.29
 
-  '@slate-yjs/react@1.1.0(@slate-yjs/core@1.0.2(slate@0.124.1)(yjs@13.6.29))(react@19.2.4)(slate-react@0.124.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)(yjs@13.6.29)':
+  '@slate-yjs/react@1.1.0(@slate-yjs/core@1.0.2(slate@0.124.1)(yjs@13.6.29))(react@19.2.4)(slate-react@0.124.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)(yjs@13.6.29)':
     dependencies:
       '@slate-yjs/core': 1.0.2(slate@0.124.1)(yjs@13.6.29)
       react: 19.2.4
       slate: 0.124.1
-      slate-react: 0.124.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
+      slate-react: 0.124.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
       use-sync-external-store: 1.6.0(react@19.2.4)
       y-protocols: 1.0.7(yjs@13.6.29)
       yjs: 13.6.29
@@ -19333,7 +19332,7 @@ snapshots:
       is-plain-object: 5.0.0
       slate: 0.124.1
 
-  slate-react@0.124.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1):
+  slate-react@0.124.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1):
     dependencies:
       '@juggle/resize-observer': 3.4.0
       direction: 1.0.4
@@ -19346,7 +19345,7 @@ snapshots:
       slate-dom: 0.124.1(slate@0.124.1)
       tiny-invariant: 1.3.1
 
-  slate-test-utils@1.3.2(@testing-library/jest-dom@6.6.3)(@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-react@0.124.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1):
+  slate-test-utils@1.3.2(@testing-library/jest-dom@6.6.3)(@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-react@0.124.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1):
     dependencies:
       '@testing-library/jest-dom': 6.6.3
       '@testing-library/react': 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -19356,7 +19355,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       slate: 0.124.1
-      slate-react: 0.124.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
+      slate-react: 0.124.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
 
   slate@0.124.1: {}
 


### PR DESCRIPTION
**Checklist**

- [x] `pnpm typecheck`
- [x] `pnpm lint:fix`
- [x] `bun test`
- [x] `pnpm brl`
- [x] `pnpm changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- pnpm brl: Required if adding, moving or removing a file in a package.
- pnpm changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->

## Summary by Sourcery

Respect markdown resourceLink options when serializing bare autolink literals and update related dependencies and docs.

Bug Fixes:
- Ensure bare autolink literals honor remark-stringify's resourceLink option instead of always serializing as plain URLs.

Enhancements:
- Update slate-react dependency in the core Slate package to the latest compatible version.
- Bump @platejs/markdown and @platejs/ai patch versions and record the changes in their changelogs.

Documentation:
- Clarify the markdown GFM fallback behavior, including resourceLink handling and prevention guidelines in the logic error solution doc.

Tests:
- Add a regression test verifying serialization of bare autolink literals when resourceLink is enabled.

Chores:
- Add a changeset entry for the @platejs/slate patch release.