### PR TITLE
feat(www): paginate the editor via PaginationKit in EditorKit

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -85,6 +85,7 @@
     "@platejs/math": "workspace:^",
     "@platejs/media": "workspace:^",
     "@platejs/mention": "workspace:^",
+    "@platejs/pagination": "workspace:^",
     "@platejs/playwright": "workspace:^",
     "@platejs/resizable": "workspace:^",
     "@platejs/selection": "workspace:^",

--- a/apps/www/src/registry/components/editor/editor-kit.tsx
+++ b/apps/www/src/registry/components/editor/editor-kit.tsx
@@ -33,6 +33,7 @@ import { MarkdownKit } from './plugins/markdown-kit';
 import { MathKit } from './plugins/math-kit';
 import { MediaKit } from './plugins/media-kit';
 import { MentionKit } from './plugins/mention-kit';
+import { PaginationKit } from './plugins/pagination-kit';
 import { SlashKit } from './plugins/slash-kit';
 import { SuggestionKit } from './plugins/suggestion-kit';
 import { TableKit } from './plugins/table-kit';
@@ -42,6 +43,9 @@ import { ToggleKit } from './plugins/toggle-kit';
 export const EditorKit = [
   ...AIKit,
   ...BlockMenuKit,
+
+  // Layout
+  ...PaginationKit,
 
   // Elements
   ...BasicBlocksKit,

--- a/apps/www/src/registry/components/editor/plugins/pagination-kit.tsx
+++ b/apps/www/src/registry/components/editor/plugins/pagination-kit.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import { PaginationPlugin } from '@platejs/pagination';
+
+export const PaginationKit = [PaginationPlugin];


### PR DESCRIPTION
Stacked on #(pagination auto-mount).

## What
- Add `@platejs/pagination` dep to `apps/www`
- New `PaginationKit` (`plugins/pagination-kit.tsx`)
- Wire `...PaginationKit` into the main `EditorKit`

## Impact
The main `EditorKit` is now paginated wherever it's used (playground/dev, server-side example, slate-to-html). Static-HTML serialization tests (render/elements/marks) pass — serialized output is unchanged.

## Verification
- apps/www typecheck passes (incl. package-integration config)
- lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)