### PR TITLE
fix(playground-template): make pagination work (drop TrailingBlock conflict)

### DIFF
--- a/templates/plate-playground-template/src/components/editor/editor-kit.tsx
+++ b/templates/plate-playground-template/src/components/editor/editor-kit.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TrailingBlockPlugin, type Value } from 'platejs';
+import { type Value } from 'platejs';
 import { type TPlateEditor, useEditorRef } from 'platejs/react';
 
 import { AIKit } from '@/components/editor/plugins/ai-kit';
@@ -82,7 +82,8 @@ export const EditorKit = [
   ...DndKit,
   ...EmojiKit,
   ...ExitBreakKit,
-  TrailingBlockPlugin,
+  // TrailingBlockPlugin omitted: it enforces a trailing block at the editor
+  // root, which conflicts with PaginationKit wrapping root content into pages.
 
   // Parsers
   ...DocxKit,

--- a/templates/plate-playground-template/src/components/editor/plugins/pagination-kit.tsx
+++ b/templates/plate-playground-template/src/components/editor/plugins/pagination-kit.tsx
@@ -1,20 +1,16 @@
 'use client';
 
-import {
-  PaginationCoordinator,
-  PaginationPlugin,
-  PaginationRegistryProvider,
-} from '@platejs/pagination';
+import { PaginationPlugin } from '@platejs/pagination';
 
 /**
- * Pagination kit — variant A (render-time overlay).
+ * Pagination kit.
  *
- * Painted as an absolute overlay on top of the editor; pages are derived
- * per render and the document model never changes. See `@platejs/pagination`.
+ * `PaginationPlugin` auto-mounts its registry provider + reflow coordinator
+ * (via `render.aboveEditable`), so only options need configuring here.
  *
- * Render is bound at the kit level (not the package) so the JSX boundary
- * lives inside this `'use client'` file — mirrors the `CursorOverlayKit`
- * pattern used by other Plate plugins.
+ * Note: pagination wraps root content into `page` nodes, which is incompatible
+ * with `TrailingBlockPlugin` (it enforces a trailing block at the editor root) —
+ * they fight during normalization. Do not enable both in the same editor.
  */
 export const PaginationKit = [
   PaginationPlugin.configure({
@@ -23,13 +19,6 @@ export const PaginationKit = [
         margins: { bottom: 96, left: 72, right: 72, top: 96 },
         sizes: { width: 794, height: 1123 }, // A4 at 96 DPI
       },
-    },
-    render: {
-      afterEditable: () => (
-        <PaginationRegistryProvider>
-          <PaginationCoordinator />
-        </PaginationRegistryProvider>
-      ),
     },
   }),
 ];

--- a/templates/plate-playground-template/src/components/editor/plugins/suggestion-kit.tsx
+++ b/templates/plate-playground-template/src/components/editor/plugins/suggestion-kit.tsx
@@ -11,7 +11,7 @@ import type {
   TSuggestionData,
   TSuggestionText,
 } from 'platejs';
-import { KEYS, TextApi, TrailingBlockPlugin } from 'platejs';
+import { KEYS, TextApi } from 'platejs';
 import { toTPlatePlugin } from 'platejs/react';
 
 import {
@@ -127,12 +127,6 @@ export const suggestionPlugin = toTPlatePlugin<SuggestionConfig>(
   },
 });
 
-const trailingBlockPlugin = TrailingBlockPlugin.configure({
-  options: {
-    insert: (editor, { insert }) => {
-      editor.getApi(suggestionPlugin).suggestion.withoutSuggestions(insert);
-    },
-  },
-});
-
-export const SuggestionKit = [suggestionPlugin, trailingBlockPlugin];
+// TrailingBlockPlugin omitted: it enforces a trailing block at the editor root,
+// which conflicts with PaginationKit wrapping root content into pages.
+export const SuggestionKit = [suggestionPlugin];


### PR DESCRIPTION
Makes the playground template's pagination actually render pages. Pairs with the `@platejs/pagination` fixes in #405.

## Changes (template source)
- **editor-kit.tsx / suggestion-kit.tsx**: remove `TrailingBlockPlugin`. It enforces a trailing block at the editor root, which is mutually exclusive with `PaginationKit` wrapping root content into `page` nodes — together they cause an infinite normalization loop ("Could not completely normalize the editor after N iterations").
- **pagination-kit.tsx**: simplify to rely on `PaginationPlugin`'s auto-mounted registry provider + reflow coordinator (from #405) instead of wiring them manually in `render.afterEditable`.

## Why template source (not registry)
The template's pagination is a template-specific overlay — the apps/www `editor-ai` registry block (the template's editor source) has no pagination, and the trailing-block exclusion only applies when pagination is present, so it can't live in the generic registry without breaking apps/www / the editor-ai demo.

## Depends on
#405 (package auto-mount + literal key). The vendored package (`vendor/platejs-pagination/dist`, gitignored) is repopulated by `vendor:pagination` / CI after the package change lands.

## Verified
Deployed live to Cloudflare Workers via `deploy:playground`: https://plate-playground.cicero-im.workers.dev/editor — 3 A4 pages render with page numbers, and the Page-preview toggle switches paginated ↔ continuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)