### PR TITLE
fix(pagination): key measure cache by (id, width) — F-006 (PR2/stack)

### DIFF
--- a/.changeset/pagination-cache-key.md
+++ b/.changeset/pagination-cache-key.md
@@ -1,0 +1,5 @@
+---
+"@platejs/pagination": patch
+---
+
+Fix `measureSnapshot` cache thrashing when the same block is measured at multiple widths. The cache now keys each entry by `(block id, width)` instead of block id alone, so alternating widths (resize, side-by-side editors) stay cached instead of overwriting one slot.

--- a/packages/pagination/src/measure/__tests__/measure.spec.ts
+++ b/packages/pagination/src/measure/__tests__/measure.spec.ts
@@ -61,6 +61,20 @@ describe('measureSnapshot', () => {
     expect(calls).toBe(2);
   });
 
+  it('keeps each (id, width) cached when widths alternate (no thrash)', () => {
+    const cache = new Map();
+    let calls = 0;
+    const measure = () => {
+      calls += 1;
+      return { heightPx: 100, lineHeightPx: 20 };
+    };
+    measureSnapshot(snap(ub('a')), measure, { cache, widthPx: 600 });
+    measureSnapshot(snap(ub('a')), measure, { cache, widthPx: 500 });
+    // width 600 was already measured — must be a cache hit, not a re-measure.
+    measureSnapshot(snap(ub('a')), measure, { cache, widthPx: 600 });
+    expect(calls).toBe(2);
+  });
+
   it('carries over pagination hints from the unmeasured block', () => {
     const measure = () => ({ heightPx: 100, lineHeightPx: 20 });
     const out = measureSnapshot(

--- a/packages/pagination/src/measure/measure.ts
+++ b/packages/pagination/src/measure/measure.ts
@@ -25,7 +25,7 @@ export type BlockMetrics = {
 
 export type MeasureFn = (block: UnmeasuredBlock) => BlockMetrics | null;
 
-export type MeasureCache = Map<string, { key: string; metrics: BlockMetrics }>;
+export type MeasureCache = Map<string, BlockMetrics>;
 
 export type MeasureOptions = {
   /** Content width the blocks are measured at (part of the cache key). */
@@ -50,15 +50,14 @@ export function measureSnapshot(
   const { cache, fallbackLineHeightPx = 20, widthPx } = options;
 
   const blocks: MeasuredBlock[] = snapshot.blocks.map((block) => {
+    // Cache slot is per (block, width): a single id measured at two widths must
+    // keep both, or alternating widths thrash one slot and defeat the cache.
     const cacheKey = `${block.id}@${widthPx}`;
-    let metrics: BlockMetrics | null = null;
+    let metrics: BlockMetrics | null = cache?.get(cacheKey) ?? null;
 
-    const cached = cache?.get(block.id);
-    if (cached && cached.key === cacheKey) {
-      metrics = cached.metrics;
-    } else {
+    if (!metrics) {
       metrics = measure(block);
-      if (metrics && cache) cache.set(block.id, { key: cacheKey, metrics });
+      if (metrics && cache) cache.set(cacheKey, metrics);
     }
 
     const heightPx = metrics?.heightPx ?? fallbackLineHeightPx;


### PR DESCRIPTION
## PR2 of the pagination rewrite stack — stacked on #408

Fixes **F-006**: `measureSnapshot`'s cache was keyed by `block.id` alone while the logical key included width, so one block measured at two widths thrashed a single slot (resize storms, side-by-side editors).

### Change
- `MeasureCache` entries keyed by `${block.id}@${widthPx}`; removed the now-redundant inner `key` field (type simplified to `Map<string, BlockMetrics>`).

### TDD
- RED: alternating-width test (600→500→600) re-measured the third time (`calls === 3`).
- GREEN: width 600 stays cached → `calls === 2`.

### Verification
- `bun test` (pagination): **33 pass / 0 fail**
- typecheck: **green** · lint: **clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)