### PR TITLE
feat(pagination): snapshot carries block text (PR4/stack)

### DIFF
--- a/.changeset/pagination-snapshot-text.md
+++ b/.changeset/pagination-snapshot-text.md
@@ -1,0 +1,5 @@
+---
+"@platejs/pagination": patch
+---
+
+`buildSnapshot` now records each block's concatenated `text` on the snapshot, so the measurement pass can line-break it.

--- a/packages/pagination/src/layout/__tests__/snapshot.spec.ts
+++ b/packages/pagination/src/layout/__tests__/snapshot.spec.ts
@@ -13,6 +13,18 @@ describe('buildSnapshot', () => {
     expect(snap.blocks.map((b) => b.type)).toEqual(['p', 'p', 'p']);
   });
 
+  it('carries the concatenated text of each block (for line measurement)', () => {
+    const snap = buildSnapshot(
+      [
+        { children: [{ text: 'Hello ' }, { text: 'world' }], type: 'p' },
+        p('second'),
+      ],
+      {}
+    );
+    expect(snap.blocks[0].text).toBe('Hello world');
+    expect(snap.blocks[1].text).toBe('second');
+  });
+
   it('uses node.id as the stable id when present', () => {
     const snap = buildSnapshot([p('a', { id: 'fixed-1' })], {});
     expect(snap.blocks[0].id).toBe('fixed-1');

--- a/packages/pagination/src/layout/snapshot.ts
+++ b/packages/pagination/src/layout/snapshot.ts
@@ -61,6 +61,7 @@ export function buildSnapshot(
     const block: UnmeasuredBlock = {
       id: stableId(node),
       path: [index],
+      text: nodeText(node),
       type,
     };
 

--- a/packages/pagination/src/layout/types.ts
+++ b/packages/pagination/src/layout/types.ts
@@ -81,6 +81,8 @@ export type UnmeasuredBlock = {
   id: string;
   path: number[];
   type: string;
+  /** Concatenated text of the block, used for line measurement. */
+  text: string;
   keepWithNext?: boolean;
   breakBefore?: boolean;
   splittable?: boolean;

--- a/packages/pagination/src/measure/__tests__/measure.spec.ts
+++ b/packages/pagination/src/measure/__tests__/measure.spec.ts
@@ -7,6 +7,7 @@ const ub = (
 ): UnmeasuredBlock => ({
   id,
   path: [0],
+  text: '',
   type: 'p',
   ...extra,
 });


### PR DESCRIPTION
## PR4 — stacked on #410

`buildSnapshot` now records each block's concatenated `text` (required field on `UnmeasuredBlock`) so the measurement pass can line-break it with pretext. TDD red→green; updated the `ub()` test helper + snapshot test.

Verification: 37 tests pass, typecheck green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)