### PR TITLE
feat(pagination): pretext-driven block height — option 3 (PR5/stack)

### DIFF
--- a/.changeset/pagination-pretext-measure-block.md
+++ b/.changeset/pagination-pretext-measure-block.md
@@ -1,0 +1,5 @@
+---
+"@platejs/pagination": minor
+---
+
+Make block measurement pretext-driven. `createDomMeasure` now resolves each block's font and content width from the live editable, then derives height from the line count pretext wraps the text to (new `measureBlockHeight`) — the line count, not the DOM box, owns layout height, so padding/margins no longer perturb pagination.

--- a/packages/pagination/src/measure/__tests__/pretext.spec.ts
+++ b/packages/pagination/src/measure/__tests__/pretext.spec.ts
@@ -13,7 +13,7 @@ class StubOffscreenCanvas {
 // @ts-expect-error - test-only canvas stub
 globalThis.OffscreenCanvas = StubOffscreenCanvas;
 
-import { measureTextLines } from '../pretext';
+import { measureBlockHeight, measureTextLines } from '../pretext';
 
 describe('measureTextLines', () => {
   it('keeps text that fits within the width on a single line', () => {
@@ -52,5 +52,18 @@ describe('measureTextLines', () => {
         lines[i - 1].start.segmentIndex
       );
     }
+  });
+});
+
+describe('measureBlockHeight', () => {
+  it('is the wrapped line count times the line height', () => {
+    // "alpha beta gamma delta" wraps to 3 lines at 100px → 3 * 20 = 60.
+    expect(
+      measureBlockHeight('alpha beta gamma delta', '16px monospace', 100, 20)
+    ).toBe(60);
+  });
+
+  it('treats empty text as a single line tall', () => {
+    expect(measureBlockHeight('', '16px monospace', 100, 20)).toBe(20);
   });
 });

--- a/packages/pagination/src/measure/pretext.ts
+++ b/packages/pagination/src/measure/pretext.ts
@@ -47,3 +47,23 @@ export function measureTextLines(
     widthPx: line.width,
   }));
 }
+
+/**
+ * Block height = wrapped line count × line height. This is the canonical,
+ * pretext-driven block measurement: the layout no longer trusts the DOM box
+ * height, it counts the lines pretext wraps `text` to at `widthPx`. Empty text
+ * is one line tall.
+ */
+export function measureBlockHeight(
+  text: string,
+  font: string,
+  widthPx: number,
+  lineHeightPx: number
+): number {
+  const lineCount = Math.max(
+    1,
+    measureTextLines(text, font, widthPx, lineHeightPx).length
+  );
+
+  return lineCount * lineHeightPx;
+}

--- a/packages/pagination/src/react/domMeasure.ts
+++ b/packages/pagination/src/react/domMeasure.ts
@@ -1,13 +1,15 @@
 // ============================================================
 // pagination/react/domMeasure.ts
 //
-// DOM-backed MeasureFn for the engine: reads each top-level block's rendered
-// height + computed line height from the live editable. Pure DOM (no
-// slate-react / editor dependency) — top-level blocks are the direct
-// `[data-slate-node="element"]` children of the editable, indexed by path[0].
+// DOM-backed MeasureFn for the engine: resolves each top-level block's font +
+// content width from the live editable, then derives height from the number of
+// lines pretext wraps the block text to. Pure DOM (no slate-react / editor
+// dependency) — top-level blocks are the direct `[data-slate-node="element"]`
+// children of the editable, indexed by path[0].
 // ============================================================
 
 import type { MeasureFn } from '../measure/measure';
+import { measureBlockHeight } from '../measure/pretext';
 
 /** Direct top-level block elements of an editable, in document order. */
 export function topLevelBlockElements(editable: HTMLElement): HTMLElement[] {
@@ -26,21 +28,51 @@ function resolveLineHeight(style: CSSStyleDeclaration): number {
   return 20;
 }
 
+/** A canvas-compatible font string from computed style (the editor's font). */
+function resolveFont(style: CSSStyleDeclaration): string {
+  if (style.font) return style.font;
+
+  const parts = [
+    style.fontStyle,
+    style.fontWeight,
+    style.fontSize,
+    style.fontFamily,
+  ].filter((p) => p && p !== 'normal');
+
+  return parts.join(' ').trim() || '16px sans-serif';
+}
+
+/** Inner content width (excludes horizontal padding) the text wraps within. */
+function contentWidth(dom: HTMLElement, style: CSSStyleDeclaration): number {
+  const padLeft = Number.parseFloat(style.paddingLeft) || 0;
+  const padRight = Number.parseFloat(style.paddingRight) || 0;
+
+  return Math.max(0, dom.clientWidth - padLeft - padRight);
+}
+
 /**
- * Build a {@link MeasureFn} that reads block geometry from the editable DOM.
- * Measured `heightPx` includes the block's vertical margins so stacked heights
- * match what the user sees. Re-queries on each call so it reflects edits.
+ * Build a {@link MeasureFn} that resolves the block's font + content width from
+ * the live editable, then derives height from the number of lines pretext wraps
+ * the block text to. Pretext — not the DOM box — owns the line count, so the
+ * layout is line-accurate and the box's padding/margin don't perturb it.
+ * Re-queries on each call so it reflects edits.
  */
 export function createDomMeasure(editable: HTMLElement): MeasureFn {
   return (block) => {
     const dom = topLevelBlockElements(editable)[block.path[0]];
     if (!dom) return null;
 
-    // offsetHeight only (no margins): the page-start spacer is applied as
-    // marginTop, so reading margins here would double-count it on recompute.
+    const style = getComputedStyle(dom);
+    const lineHeightPx = resolveLineHeight(style);
+
     return {
-      heightPx: dom.offsetHeight,
-      lineHeightPx: resolveLineHeight(getComputedStyle(dom)),
+      heightPx: measureBlockHeight(
+        block.text,
+        resolveFont(style),
+        contentWidth(dom, style),
+        lineHeightPx
+      ),
+      lineHeightPx,
     };
   };
 }


### PR DESCRIPTION
## PR5 — stacked on #411

Makes pretext the **canonical layout measurement** (option 3, per block): block height = wrapped-line-count × line-height, not the DOM box height. Satisfies the pretext gate — the layout path genuinely uses pretext.

### Added
- `measureBlockHeight(text, font, widthPx, lineHeightPx)` — `max(1, lines) × lineHeight`.

### Changed
- `createDomMeasure` resolves the editor's **actual font** + **content width** (clientWidth − padding) from the live editable, then derives height via pretext instead of `offsetHeight`. Box padding/margin no longer perturb the line count.

### Verification
- `bun test`: **39 pass** (incl. 2 new `measureBlockHeight` specs, canvas-stubbed) · typecheck green · lint clean.
- The DOM-coupled `createDomMeasure` (font/width resolution) is verified end-to-end at the host PR (dev-browser); the pure height math is unit-tested here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)