### PR TITLE
refactor(pagination): compose places blocks whole — option C (PR6/stack)

### DIFF
--- a/.changeset/pagination-compose-place-whole.md
+++ b/.changeset/pagination-compose-place-whole.md
@@ -1,0 +1,5 @@
+---
+"@platejs/pagination": patch
+---
+
+`composeLayout` places blocks whole: a block that fits the remaining space is placed, otherwise it moves whole to the next page; a block taller than a full page is placed and overflows. No mid-block splitting.

--- a/packages/pagination/src/layout/__tests__/compose.spec.ts
+++ b/packages/pagination/src/layout/__tests__/compose.spec.ts
@@ -7,7 +7,6 @@ const INPUT: LayoutInput = {
   margins: { topPx: 96, rightPx: 96, bottomPx: 96, leftPx: 96 },
   policies: { widowLinesMin: 2, orphanLinesMin: 2, keepWithNextEnabled: true },
 };
-const FRAME_H = 931;
 const LH = 20;
 
 let nextId = 0;
@@ -28,16 +27,16 @@ function block(
 function snap(...blocks: MeasuredBlock[]): MeasuredSnapshot {
   return { blocks };
 }
-const allFrags = (out: ReturnType<typeof composeLayout>) =>
-  out.pages.flatMap((p) => p.frames.flatMap((f) => f.fragments));
 
-describe('composeLayout', () => {
+describe('composeLayout (place-whole / option C)', () => {
   it('places blocks that fit on a single page, stacked by height', () => {
     const out = composeLayout(snap(block(100), block(100), block(100)), INPUT);
     expect(out.pages).toHaveLength(1);
     const frags = out.pages[0].frames[0].fragments;
     expect(frags.map((f) => f.y)).toEqual([0, 100, 200]);
+    // every block is one whole fragment.
     expect(frags.every((f) => f.fragmentIndex === 0)).toBe(true);
+    expect(frags.every((f) => f.lineStart === 0)).toBe(true);
     expect(out.metrics).toEqual({ pages: 1, blocks: 3 });
   });
 
@@ -51,34 +50,23 @@ describe('composeLayout', () => {
     });
   });
 
-  it('moves a whole non-splittable block to the next page when it does not fit', () => {
-    const out = composeLayout(
-      snap(block(700), block(400, { splittable: false })),
-      INPUT
-    );
+  it('moves a block whole to the next page when it does not fit the remaining space', () => {
+    const out = composeLayout(snap(block(700), block(400)), INPUT);
     expect(out.pages).toHaveLength(2);
     expect(out.pages[0].frames[0].fragments).toHaveLength(1);
     const p2first = out.pages[1].frames[0].fragments[0];
     expect(p2first.breakReason).toBe('block_overflow');
     expect(p2first.y).toBe(0);
+    expect(p2first.heightPx).toBe(400);
   });
 
-  it('splits a splittable block across pages by line height', () => {
-    // 2000px / 20 = 100 lines; frame fits floor(931/20)=46 lines.
+  it('places a block taller than a full page on its own page, accepting overflow', () => {
     const out = composeLayout(snap(block(2000)), INPUT);
-    expect(out.pages.length).toBe(3); // 46 + 46 + 8
-    const frags = allFrags(out);
-    expect(frags.map((f) => f.fragmentIndex)).toEqual([0, 1, 2]);
-    expect(frags.map((f) => f.lineStart)).toEqual([0, 46, 92]);
-    expect(frags.reduce((n, f) => n + f.lineCount, 0)).toBe(100);
-    expect(frags.every((f) => f.blockId === frags[0].blockId)).toBe(true);
-  });
-
-  it('places an oversized non-splittable block on its own page (accepts overflow)', () => {
-    const out = composeLayout(snap(block(2000, { splittable: false })), INPUT);
     expect(out.pages).toHaveLength(1);
-    expect(out.pages[0].frames[0].fragments).toHaveLength(1);
-    expect(out.pages[0].frames[0].fragments[0].heightPx).toBe(2000);
+    const frags = out.pages[0].frames[0].fragments;
+    expect(frags).toHaveLength(1);
+    expect(frags[0].heightPx).toBe(2000);
+    expect(frags[0].fragmentIndex).toBe(0);
   });
 
   it('respects manual page breaks (breakBefore)', () => {
@@ -103,15 +91,6 @@ describe('composeLayout', () => {
     const p2 = out.pages[1].frames[0].fragments;
     expect(p2).toHaveLength(2); // A + B together
     expect(p2[0].breakReason).toBe('keep_with_next');
-  });
-
-  it('pushes a block down to avoid an orphan (fewer than orphanMin lines at bottom)', () => {
-    // filler leaves only 1 line of room; next block must not orphan a single line.
-    const out = composeLayout(snap(block(FRAME_H - LH), block(200)), INPUT);
-    expect(out.pages).toHaveLength(2);
-    expect(out.pages[1].frames[0].fragments[0].breakReason).toBe(
-      'widow_orphan'
-    );
   });
 
   it('is deterministic — identical input yields identical output', () => {

--- a/packages/pagination/src/layout/compose.ts
+++ b/packages/pagination/src/layout/compose.ts
@@ -6,9 +6,10 @@
 // LayoutOutput of pages → frames → block fragments. No DOM, no document
 // mutation — same input always yields identical output.
 //
-// Block-level adaptation of premirror's line-fill composer: a top-level Slate
-// block is the atomic unit, and a tall splittable block is fragmented across
-// pages by its measured line height.
+// Block-level, place-whole composer (option C): a top-level Slate block is the
+// atomic unit. A block that fits the remaining space is placed; otherwise it
+// moves whole to the next page. A block taller than a full page is placed whole
+// and overflows its page (no mid-block splitting, no clones).
 // ============================================================
 
 import type {
@@ -23,29 +24,6 @@ import type {
   Rect,
 } from './types';
 
-/**
- * How many of `remainingLines` may sit at the bottom of the current page given
- * `cap` lines of physical room, honoring widow/orphan minimums. Returns 0 to
- * push the whole (remaining) block to the next page.
- */
-function linesToPlace(
-  remainingLines: number,
-  cap: number,
-  widowMin: number,
-  orphanMin: number
-): number {
-  if (cap >= remainingLines) return remainingLines;
-  if (cap <= 0) return 0;
-  // Orphan guard: too few lines would be stranded at the bottom.
-  if (cap < orphanMin) return 0;
-  // Widow guard: ensure the next page keeps at least `widowMin` lines.
-  if (remainingLines - cap < widowMin) {
-    const alt = remainingLines - widowMin;
-    return alt >= orphanMin ? alt : 0;
-  }
-  return cap;
-}
-
 export function composeLayout(
   snapshot: MeasuredSnapshot,
   input: LayoutInput
@@ -58,8 +36,6 @@ export function composeLayout(
     height: page.heightPx - margins.topPx - margins.bottomPx,
   };
   const frameHeight = bounds.height;
-  const widowMin = policies.widowLinesMin;
-  const orphanMin = policies.orphanLinesMin;
 
   const pages: PageLayout[] = [];
   let fragments: BlockFragment[] = [];
@@ -85,81 +61,23 @@ export function composeLayout(
   };
 
   const placeBlock = (b: MeasuredBlock) => {
-    const splittable = b.splittable !== false;
-
-    if (b.heightPx <= frameHeight - currentY) {
-      push({
-        blockId: b.id,
-        fragmentIndex: 0,
-        heightPx: b.heightPx,
-        lineCount: b.lineCount,
-        lineStart: 0,
-        path: b.path,
-        y: currentY,
-      });
-      currentY += b.heightPx;
-
-      return;
+    // Place the block whole. If it doesn't fit the remaining space and we're not
+    // already at the top of a fresh page, move it whole to the next page. A
+    // block taller than a full frame is placed at the top and overflows.
+    if (b.heightPx > frameHeight - currentY && fragments.length > 0) {
+      breakToNewPage('block_overflow');
     }
 
-    if (!splittable) {
-      // Move the whole block to a fresh page (unless already at the top, in
-      // which case it overflows the page — nothing better we can do).
-      if (fragments.length > 0) breakToNewPage('block_overflow');
-      push({
-        blockId: b.id,
-        fragmentIndex: 0,
-        heightPx: b.heightPx,
-        lineCount: b.lineCount,
-        lineStart: 0,
-        path: b.path,
-        y: currentY,
-      });
-      currentY += b.heightPx;
-
-      return;
-    }
-
-    // Splittable: emit fragments across pages by measured line height.
-    const lineHeight = b.lineHeightPx;
-    const total = b.lineCount;
-    let placed = 0;
-    let fragmentIndex = 0;
-
-    while (placed < total) {
-      const cap = Math.floor((frameHeight - currentY) / lineHeight);
-      const remainingLines = total - placed;
-      let fit = linesToPlace(remainingLines, cap, widowMin, orphanMin);
-
-      if (fit <= 0) {
-        if (fragments.length === 0) {
-          // Fresh page and still nothing fits (block taller than a full frame):
-          // force at least one chunk to make progress.
-          fit = cap >= remainingLines ? remainingLines : Math.max(1, cap);
-        } else {
-          breakToNewPage(
-            cap > 0 && cap < orphanMin ? 'widow_orphan' : 'block_overflow'
-          );
-          continue;
-        }
-      }
-
-      const heightPx = fit * lineHeight;
-      push({
-        blockId: b.id,
-        fragmentIndex,
-        heightPx,
-        lineCount: fit,
-        lineStart: placed,
-        path: b.path,
-        y: currentY,
-      });
-      placed += fit;
-      fragmentIndex += 1;
-      currentY += heightPx;
-
-      if (placed < total) flushPage();
-    }
+    push({
+      blockId: b.id,
+      fragmentIndex: 0,
+      heightPx: b.heightPx,
+      lineCount: b.lineCount,
+      lineStart: 0,
+      path: b.path,
+      y: currentY,
+    });
+    currentY += b.heightPx;
   };
 
   const blocks = snapshot.blocks;


### PR DESCRIPTION
## PR6 — stacked on #412

Simplifies `composeLayout` to the chosen render model (option C): blocks are placed **whole** — fit-or-next-page, oversized overflows. Removes the line-splitting + widow/orphan path and the `linesToPlace` helper.

### TDD
- compose.spec rewritten to the place-whole contract; oversized-block case RED (split to 3 pages) → GREEN (1 page whole, overflow). Dropped split + orphan tests (behavior removed by design).

### Verification
- `bun test`: **37 pass** · typecheck green · lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)