### PR TITLE
feat(pagination): build MappingIndex once in composeLayout, expose on LayoutOutput

### DIFF
--- a/.changeset/pagination-mapping-in-output.md
+++ b/.changeset/pagination-mapping-in-output.md
@@ -1,0 +1,5 @@
+---
+"@platejs/pagination": patch
+---
+
+Build the layout `MappingIndex` once during `composeLayout` and expose it on `LayoutOutput.mapping`; projection reads it instead of rebuilding the index on every call.

--- a/packages/pagination/src/layout/__tests__/compose.spec.ts
+++ b/packages/pagination/src/layout/__tests__/compose.spec.ts
@@ -107,4 +107,14 @@ describe('composeLayout (place-whole / option C)', () => {
     expect(out.pages).toHaveLength(1);
     expect(out.pages[0].frames[0].fragments).toHaveLength(0);
   });
+
+  it('includes a MappingIndex in LayoutOutput, built during composition', () => {
+    const out = composeLayout(
+      snap(block(700, { path: [0] }), block(400, { path: [1] })),
+      INPUT
+    );
+    // 700 fits page 0; 400 overflows to page 1.
+    expect(out.mapping.pageOfBlock(0)).toBe(0);
+    expect(out.mapping.pageOfBlock(1)).toBe(1);
+  });
 });

--- a/packages/pagination/src/layout/__tests__/mapping.spec.ts
+++ b/packages/pagination/src/layout/__tests__/mapping.spec.ts
@@ -1,5 +1,5 @@
 import { buildMappingIndex } from '../mapping';
-import type { BlockFragment, LayoutOutput, PageLayout } from '../types';
+import type { BlockFragment, PageLayout } from '../types';
 
 const spec = { widthPx: 794, heightPx: 1123, preset: 'a4' as const };
 const bounds = { x: 96, y: 96, width: 602, height: 931 };
@@ -23,34 +23,31 @@ function frag(
 function page(index: number, fragments: BlockFragment[]): PageLayout {
   return { frames: [{ bounds, fragments }], index, spec };
 }
-function out(pages: PageLayout[]): LayoutOutput {
-  return { metrics: { blocks: 0, pages: pages.length }, pages };
-}
 
 // Block 0: whole on page 0. Block 1: split across pages 0,1,2 (lines 0-9,10-19,20-24).
-const layout = out([
+const pages: PageLayout[] = [
   page(0, [frag([0], 0, 0, 5), frag([1], 0, 0, 10)]),
   page(1, [frag([1], 1, 10, 10)]),
   page(2, [frag([1], 2, 20, 5)]),
-]);
+];
 
 describe('buildMappingIndex', () => {
   it('returns all fragments of a block across pages, in order', () => {
-    const idx = buildMappingIndex(layout);
+    const idx = buildMappingIndex(pages);
     const refs = idx.fragmentsOfBlock(1);
     expect(refs.map((r) => r.pageIndex)).toEqual([0, 1, 2]);
     expect(refs.map((r) => r.fragment.lineStart)).toEqual([0, 10, 20]);
   });
 
   it('pageOfBlock returns the first fragment page', () => {
-    const idx = buildMappingIndex(layout);
+    const idx = buildMappingIndex(pages);
     expect(idx.pageOfBlock(0)).toBe(0);
     expect(idx.pageOfBlock(1)).toBe(0);
     expect(idx.pageOfBlock(99)).toBeNull();
   });
 
   it('maps a block line to its containing page (caret mapping)', () => {
-    const idx = buildMappingIndex(layout);
+    const idx = buildMappingIndex(pages);
     expect(idx.pageOfBlockLine(1, 3)).toBe(0); // line 3 → first fragment
     expect(idx.pageOfBlockLine(1, 12)).toBe(1); // line 12 → second fragment
     expect(idx.pageOfBlockLine(1, 24)).toBe(2); // last line → third fragment
@@ -58,14 +55,14 @@ describe('buildMappingIndex', () => {
   });
 
   it('fragmentOfBlockLine returns the fragment ref containing the line', () => {
-    const idx = buildMappingIndex(layout);
+    const idx = buildMappingIndex(pages);
     const ref = idx.fragmentOfBlockLine(1, 12);
     expect(ref?.pageIndex).toBe(1);
     expect(ref?.fragment.fragmentIndex).toBe(1);
   });
 
   it('isSplit reports blocks spanning multiple pages', () => {
-    const idx = buildMappingIndex(layout);
+    const idx = buildMappingIndex(pages);
     expect(idx.isSplit(0)).toBe(false);
     expect(idx.isSplit(1)).toBe(true);
   });

--- a/packages/pagination/src/layout/__tests__/projection.spec.ts
+++ b/packages/pagination/src/layout/__tests__/projection.spec.ts
@@ -1,4 +1,5 @@
 import { getPageGeometry } from '../../react/geometry';
+import { buildMappingIndex } from '../mapping';
 import { blockLinePosition, fragmentRects } from '../projection';
 import type { BlockFragment, LayoutOutput, PageLayout } from '../types';
 
@@ -29,17 +30,17 @@ function frag(
 function page(index: number, fragments: BlockFragment[]): PageLayout {
   return { frames: [{ bounds, fragments }], index, spec };
 }
+const layoutPages: PageLayout[] = [
+  page(0, [
+    frag([0], { fragmentIndex: 0, lineStart: 0, lineCount: 5, y: 0 }),
+    frag([1], { fragmentIndex: 0, lineStart: 0, lineCount: 40, y: 100 }),
+  ]),
+  page(1, [frag([1], { fragmentIndex: 1, lineStart: 40, lineCount: 6, y: 0 })]),
+];
 const layout: LayoutOutput = {
+  mapping: buildMappingIndex(layoutPages),
   metrics: { blocks: 2, pages: 2 },
-  pages: [
-    page(0, [
-      frag([0], { fragmentIndex: 0, lineStart: 0, lineCount: 5, y: 0 }),
-      frag([1], { fragmentIndex: 0, lineStart: 0, lineCount: 40, y: 100 }),
-    ]),
-    page(1, [
-      frag([1], { fragmentIndex: 1, lineStart: 40, lineCount: 6, y: 0 }),
-    ]),
-  ],
+  pages: layoutPages,
 };
 const geo = getPageGeometry(layout, 24);
 

--- a/packages/pagination/src/layout/compose.ts
+++ b/packages/pagination/src/layout/compose.ts
@@ -12,6 +12,7 @@
 // and overflows its page (no mid-block splitting, no clones).
 // ============================================================
 
+import { buildMappingIndex } from './mapping';
 import type {
   BlockFragment,
   BreakReason,
@@ -105,5 +106,9 @@ export function composeLayout(
   // Emit the final (or only/empty) page.
   flushPage();
 
-  return { metrics: { blocks: blocks.length, pages: pages.length }, pages };
+  return {
+    mapping: buildMappingIndex(pages),
+    metrics: { blocks: blocks.length, pages: pages.length },
+    pages,
+  };
 }

--- a/packages/pagination/src/layout/mapping.ts
+++ b/packages/pagination/src/layout/mapping.ts
@@ -7,7 +7,7 @@
 // selection onto pages.
 // ============================================================
 
-import type { BlockFragment, LayoutOutput } from './types';
+import type { BlockFragment, PageLayout } from './types';
 
 export type FragmentRef = {
   pageIndex: number;
@@ -31,10 +31,10 @@ export type MappingIndex = {
   isSplit: (blockIndex: number) => boolean;
 };
 
-export function buildMappingIndex(layout: LayoutOutput): MappingIndex {
+export function buildMappingIndex(pages: PageLayout[]): MappingIndex {
   const byBlock = new Map<number, FragmentRef[]>();
 
-  layout.pages.forEach((page) => {
+  pages.forEach((page) => {
     page.frames.forEach((frame, frameIndex) => {
       for (const fragment of frame.fragments) {
         const blockIndex = fragment.path[0];

--- a/packages/pagination/src/layout/projection.ts
+++ b/packages/pagination/src/layout/projection.ts
@@ -7,7 +7,6 @@
 // ============================================================
 
 import type { PageGeometry } from '../react/geometry';
-import { buildMappingIndex } from './mapping';
 import type { LayoutOutput } from './types';
 
 export type FragmentRect = {
@@ -33,10 +32,9 @@ export function fragmentRects(
   geometry: PageGeometry,
   blockIndex: number
 ): FragmentRect[] {
-  const mapping = buildMappingIndex(layout);
   const rects: FragmentRect[] = [];
 
-  for (const ref of mapping.fragmentsOfBlock(blockIndex)) {
+  for (const ref of layout.mapping.fragmentsOfBlock(blockIndex)) {
     const placement = geometry.placements[ref.pageIndex];
     const frame = layout.pages[ref.pageIndex]?.frames[ref.frameIndex];
     if (!placement || !frame) continue;
@@ -63,8 +61,7 @@ export function blockLinePosition(
   blockIndex: number,
   line: { lineIndex: number; lineHeightPx: number }
 ): LinePosition | null {
-  const mapping = buildMappingIndex(layout);
-  const ref = mapping.fragmentOfBlockLine(blockIndex, line.lineIndex);
+  const ref = layout.mapping.fragmentOfBlockLine(blockIndex, line.lineIndex);
   if (!ref) return null;
 
   const placement = geometry.placements[ref.pageIndex];

--- a/packages/pagination/src/layout/types.ts
+++ b/packages/pagination/src/layout/types.ts
@@ -8,6 +8,8 @@
 // The document model never changes — pages are a derived projection.
 // ============================================================
 
+import type { MappingIndex } from './mapping';
+
 export type PagePreset = 'a4' | 'letter';
 
 export type PageSpec = {
@@ -140,4 +142,9 @@ export type ComposeMetrics = {
 export type LayoutOutput = {
   pages: PageLayout[];
   metrics: ComposeMetrics;
+  /**
+   * Position index over {@link pages}, built once during composition. Consumers
+   * (projection, selection) read this instead of rebuilding it per call.
+   */
+  mapping: MappingIndex;
 };

--- a/packages/pagination/src/react/__tests__/geometry.spec.ts
+++ b/packages/pagination/src/react/__tests__/geometry.spec.ts
@@ -1,3 +1,4 @@
+import { buildMappingIndex } from '../../layout/mapping';
 import type { LayoutOutput, PageLayout } from '../../layout/types';
 import { getBlockPlacements, getPageGeometry } from '../geometry';
 
@@ -8,7 +9,11 @@ function page(index: number, fragments: any[]): PageLayout {
   return { frames: [{ bounds, fragments }], index, spec };
 }
 function out(pages: PageLayout[]): LayoutOutput {
-  return { metrics: { blocks: 0, pages: pages.length }, pages };
+  return {
+    mapping: buildMappingIndex(pages),
+    metrics: { blocks: 0, pages: pages.length },
+    pages,
+  };
 }
 
 describe('getPageGeometry', () => {


### PR DESCRIPTION
**PR1 of stacked pagination foundation** (audit P5).

`composeLayout` builds the `MappingIndex` once and returns it on
`LayoutOutput.mapping`; `fragmentRects`/`blockLinePosition` consume it instead of
rebuilding the index on every call (was `projection.ts:36,66`). `buildMappingIndex`
now takes `PageLayout[]`.

Verification: 38 tests pass, typecheck 8/8, biome clean. + changeset (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)