### PR TITLE
feat(pagination): per-editor layout registry (WeakMap, dirty-on-apply)

### DIFF
--- a/packages/pagination/src/lib/__tests__/registry.spec.ts
+++ b/packages/pagination/src/lib/__tests__/registry.spec.ts
@@ -1,0 +1,56 @@
+import { createSlateEditor } from 'platejs';
+
+import type { LayoutOutput } from '../../layout/types';
+import {
+  ensureLayout,
+  getLayoutRegistry,
+  invalidateLayoutRegistry,
+  shouldInvalidateLayout,
+} from '../registry';
+
+const FAKE_LAYOUT = {
+  mapping: {} as LayoutOutput['mapping'],
+  metrics: { blocks: 0, pages: 1 },
+  pages: [],
+} satisfies LayoutOutput;
+
+describe('layout registry', () => {
+  it('starts dirty so the first read triggers a build', () => {
+    const editor = createSlateEditor();
+    expect(getLayoutRegistry(editor).dirty).toBe(true);
+  });
+
+  it('builds once on read, serves cached, rebuilds after invalidation', () => {
+    const editor = createSlateEditor();
+    let builds = 0;
+    const compute = () => {
+      builds++;
+
+      return FAKE_LAYOUT;
+    };
+
+    ensureLayout(editor, compute); // dirty → build
+    ensureLayout(editor, compute); // clean → cached
+    expect(builds).toBe(1);
+
+    invalidateLayoutRegistry(editor);
+    ensureLayout(editor, compute); // dirty again → rebuild
+    expect(builds).toBe(2);
+  });
+
+  it('treats content operations as invalidating but selection as not', () => {
+    for (const type of [
+      'insert_text',
+      'remove_text',
+      'insert_node',
+      'remove_node',
+      'split_node',
+      'merge_node',
+      'move_node',
+      'set_node',
+    ]) {
+      expect(shouldInvalidateLayout({ type })).toBe(true);
+    }
+    expect(shouldInvalidateLayout({ type: 'set_selection' })).toBe(false);
+  });
+});

--- a/packages/pagination/src/lib/registry.ts
+++ b/packages/pagination/src/lib/registry.ts
@@ -1,0 +1,86 @@
+// ============================================================
+// pagination/lib/registry.ts
+//
+// Per-editor derived-layout registry. The composed LayoutOutput is per-client
+// state (never replicated, yjs-safe), held in a WeakMap keyed by the editor and
+// rebuilt lazily: content edits mark it dirty, the next read recomputes.
+//
+// Mirrors the footnote registry pattern (packages/footnote/src/lib/registry.ts):
+// WeakMap + dirty flag + lazy rebuild. The `editor.apply` override that calls
+// invalidateLayoutRegistry on content ops lives in the plugin layer; this module
+// stays free of plugin wiring so it is unit-testable on its own.
+// ============================================================
+
+import type { SlateEditor } from 'platejs';
+
+import type { MeasureCache } from '../measure/measure';
+import type { LayoutOutput } from '../layout/types';
+
+export type LayoutRegistryEntry = {
+  /** Last composed layout, or null when never built / invalidated. */
+  output: LayoutOutput | null;
+  /** Whether {@link output} is stale and must be rebuilt on next read. */
+  dirty: boolean;
+  /** Measurement cache reused across rebuilds (keyed by block id + width). */
+  measureCache: MeasureCache;
+};
+
+const LAYOUT_REGISTRY = new WeakMap<SlateEditor, LayoutRegistryEntry>();
+
+/** Get (lazily creating) the editor's layout registry entry. Starts dirty. */
+export function getLayoutRegistry(editor: SlateEditor): LayoutRegistryEntry {
+  let entry = LAYOUT_REGISTRY.get(editor);
+
+  if (!entry) {
+    entry = { dirty: true, measureCache: new Map(), output: null };
+    LAYOUT_REGISTRY.set(editor, entry);
+  }
+
+  return entry;
+}
+
+/** Mark the editor's layout stale so the next read rebuilds it. */
+export function invalidateLayoutRegistry(editor: SlateEditor): void {
+  const entry = getLayoutRegistry(editor);
+  entry.dirty = true;
+  entry.output = null;
+}
+
+/**
+ * Return the editor's layout, rebuilding via `compute` only when dirty. The
+ * pipeline (snapshot→measure→compose) is injected so this stays pure and
+ * testable; the plugin supplies the real `compute`.
+ */
+export function ensureLayout(
+  editor: SlateEditor,
+  compute: () => LayoutOutput
+): LayoutOutput {
+  const entry = getLayoutRegistry(editor);
+
+  if (entry.dirty || !entry.output) {
+    entry.output = compute();
+    entry.dirty = false;
+  }
+
+  return entry.output;
+}
+
+/** Slate operation types that change content (and thus invalidate layout). */
+const CONTENT_OPS = new Set([
+  'insert_node',
+  'insert_text',
+  'merge_node',
+  'move_node',
+  'remove_node',
+  'remove_text',
+  'set_node',
+  'split_node',
+]);
+
+/**
+ * Whether a Slate operation changes content and so invalidates the layout.
+ * Selection-only operations (`set_selection`) do not.
+ */
+export function shouldInvalidateLayout(operation: { type: string }): boolean {
+  return CONTENT_OPS.has(operation.type);
+}


### PR DESCRIPTION
**PR3 of stacked pagination foundation.** Stacks on #414.

`lib/registry.ts`: per-editor `WeakMap<editor,{output,dirty,measureCache}>`, lazy
rebuild via injected `compute`, `shouldInvalidateLayout` predicate (content ops
yes, `set_selection` no). Footnote registry pattern. The `apply`-override that
calls it lands with the plugin (PR4).

Verification: 41 tests pass, typecheck 8/8, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)