### PR TITLE
fix(docx-io): strip local comment tracking tokens

### DIFF
--- a/packages/docx-io/src/lib/applyDocxTracking.spec.ts
+++ b/packages/docx-io/src/lib/applyDocxTracking.spec.ts
@@ -1005,6 +1005,83 @@ describe('applyDocxTracking', () => {
   });
 
   describe('applyTrackedCommentsLocal', () => {
+    it('strips tracking tokens from local comment body and fallback document content', () => {
+      const editor = createMockEditor();
+      editor.api.string = mock(() => '');
+
+      const startToken = `[[DOCX_CMT_START:${encodeURIComponent(
+        JSON.stringify({ id: 'cmt-1' })
+      )}]]`;
+      const endToken = '[[DOCX_CMT_END:cmt-1]]';
+
+      const comments: DocxImportComment[] = [
+        {
+          id: 'cmt-1',
+          text: `${startToken}Comment body${endToken}`,
+          startToken,
+          endToken,
+          hasStartToken: true,
+          hasEndToken: true,
+        },
+      ];
+
+      const result = applyTrackedCommentsLocal({
+        editor,
+        comments,
+        searchRange: createMockSearchRange(),
+        commentKey: 'comment',
+        getCommentKey: (id) => `comment_${id}`,
+        isText: () => true,
+        generateId: () => 'discussion-1',
+        documentDate: new Date(),
+      });
+
+      expect(result.discussions[0]?.documentContent).toBe('Comment body');
+      expect(result.discussions[0]?.comments?.[0]?.contentRich).toEqual([
+        { type: 'p', children: [{ text: 'Comment body' }] },
+      ]);
+    });
+
+    it('strips tracking tokens from local rich comment body text', () => {
+      const editor = createMockEditor();
+
+      const startToken = `[[DOCX_CMT_START:${encodeURIComponent(
+        JSON.stringify({ id: 'cmt-1' })
+      )}]]`;
+      const endToken = '[[DOCX_CMT_END:cmt-1]]';
+
+      const comments: DocxImportComment[] = [
+        {
+          id: 'cmt-1',
+          body: [
+            {
+              type: 'p',
+              children: [{ text: `${startToken}Rich body${endToken}` }],
+            },
+          ],
+          startToken,
+          endToken,
+          hasStartToken: true,
+          hasEndToken: true,
+        },
+      ];
+
+      const result = applyTrackedCommentsLocal({
+        editor,
+        comments,
+        searchRange: createMockSearchRange(),
+        commentKey: 'comment',
+        getCommentKey: (id) => `comment_${id}`,
+        isText: () => true,
+        generateId: () => 'discussion-1',
+        documentDate: new Date(),
+      });
+
+      expect(result.discussions[0]?.comments?.[0]?.contentRich).toEqual([
+        { type: 'p', children: [{ text: 'Rich body' }] },
+      ]);
+    });
+
     it('removes reply tokens without creating discussions', () => {
       const editor = createMockEditor();
 

--- a/packages/docx-io/src/lib/importComments.ts
+++ b/packages/docx-io/src/lib/importComments.ts
@@ -176,14 +176,40 @@ const extractCommentBodyText = (value: unknown): string => {
   return '';
 };
 
+const stripCommentBodyTokens = (value: unknown): unknown => {
+  if (typeof value === 'string') return stripDocxTrackingTokens(value);
+  if (Array.isArray(value)) return value.map(stripCommentBodyTokens);
+  if (!value || typeof value !== 'object') return value;
+
+  const record = value as Record<string, unknown>;
+  const next: Record<string, unknown> = { ...record };
+
+  if (typeof record.text === 'string') {
+    next.text = stripDocxTrackingTokens(record.text);
+  }
+  if (typeof record.value === 'string') {
+    next.value = stripDocxTrackingTokens(record.value);
+  }
+  if (Array.isArray(record.children)) {
+    next.children = record.children.map(stripCommentBodyTokens);
+  }
+
+  return next;
+};
+
 const normalizeCommentContent = (
   body: unknown,
   text?: string
 ): unknown[] | undefined => {
-  if (isPlateValue(body)) return body as unknown[];
+  const cleanBody = stripCommentBodyTokens(body);
 
-  const bodyText = extractCommentBodyText(body);
-  const contentText = (bodyText || text || '').replace(/\s+$/g, '');
+  if (isPlateValue(cleanBody)) return cleanBody as unknown[];
+
+  const bodyText = extractCommentBodyText(cleanBody);
+  const contentText = stripDocxTrackingTokens(bodyText || text || '').replace(
+    /\s+$/g,
+    ''
+  );
 
   if (!contentText) return;
 
@@ -761,14 +787,14 @@ export async function applyTrackedComments(
         ? [{ children: [{ text: commentText }], type: 'p' }]
         : undefined;
 
-        // TODO(paraId-fidelity): paraId and parentParaId from DOCX are lost here!
-        // These fields are correctly parsed by mammoth.browser.js from w15:paraId
-        // and w15:paraIdParent XML attributes, but are not passed to the API.
-        // To fix:
-        // 1. Add paraId and parentParaId to TDiscussion or TComment types
-        // 2. Update createDiscussionWithComment API to accept these fields
-        // 3. Pass docxComment.paraId and docxComment.parentParaId here
-        // Related: PR `#45` fixed reply IDs; this needs the same treatment for threading IDs
+      // TODO(paraId-fidelity): paraId and parentParaId from DOCX are lost here!
+      // These fields are correctly parsed by mammoth.browser.js from w15:paraId
+      // and w15:paraIdParent XML attributes, but are not passed to the API.
+      // To fix:
+      // 1. Add paraId and parentParaId to TDiscussion or TComment types
+      // 2. Update createDiscussionWithComment API to accept these fields
+      // 3. Pass docxComment.paraId and docxComment.parentParaId here
+      // Related: PR `#45` fixed reply IDs; this needs the same treatment for threading IDs
       const discussion = await createDiscussionWithComment.mutateAsync({
         contentRich,
         documentContent,
@@ -1011,7 +1037,10 @@ export function applyTrackedCommentsLocal(
 
         let documentContent = editor.api.string(contentRange);
         if (!documentContent || documentContent.trim().length === 0) {
-          documentContent = 'Imported comment';
+          const fallbackText = stripDocxTrackingTokens(
+            comment.text ?? ''
+          ).trim();
+          documentContent = fallbackText || 'Imported comment';
         }
 
         discussion = {


### PR DESCRIPTION
## Summary
- strip DOCX comment tracking tokens from local comment fallback document content
- strip tokens recursively from local rich comment bodies during re-import
- add regression tests for plain text and rich comment body re-import paths

## Verification
- npm exec --yes bun -- test packages/docx-io/src/lib/applyDocxTracking.spec.ts packages/docx-io/src/lib/parseDocxTracking.spec.ts
- yarn biome check packages/docx-io/src/lib/importComments.ts packages/docx-io/src/lib/applyDocxTracking.spec.ts
- yarn turbo build --filter=./packages/docx-io

Notes:
- yarn turbo typecheck --filter=./packages/docx-io still hits the same TypeScript internal Debug Failure on the unmodified PR head baseline under Node v22.15.0.
- yarn workspace @platejs/docx-io lint still reports many pre-existing package diagnostics outside the touched files.