### PR TITLE
feat(pagination): add enabled option to toggle pagination at runtime

### DIFF
--- a/.changeset/pagination-enabled-option.md
+++ b/.changeset/pagination-enabled-option.md
@@ -1,0 +1,5 @@
+---
+"@platejs/pagination": minor
+---
+
+Add an `enabled` option (default `true`) to toggle pagination at runtime. When `false`, the React layer skips layout recompute and renders no page-break overlay; the document is never affected either way. Toggle with `editor.setOption(BasePaginationPlugin, 'enabled', next)`.

--- a/packages/pagination/src/lib/BasePaginationPlugin.ts
+++ b/packages/pagination/src/lib/BasePaginationPlugin.ts
@@ -20,6 +20,15 @@ import { invalidateLayoutRegistry, shouldInvalidateLayout } from './registry';
 export type PaginationViewMode = 'continuous' | 'paged';
 
 export type PaginationOptions = {
+  /**
+   * Whether pagination is active. When `false`, the React layer skips layout
+   * recompute and renders no page-break overlay, leaving the editor untouched;
+   * the document is never mutated either way. Toggle at runtime with
+   * `editor.setOption(BasePaginationPlugin, 'enabled', next)`.
+   *
+   * @default true
+   */
+  enabled: boolean;
   page: PageSpec;
   margins: PageMargins;
   policies: LayoutPolicies;
@@ -36,6 +45,7 @@ export type PaginationConfig = PluginConfig<'pagination', PaginationOptions>;
 // (cheapest, fully native edit surface — paged is the high-fidelity opt-in).
 const DEFAULT_OPTIONS: PaginationOptions = {
   atomicTypes: [],
+  enabled: true,
   keepWithNextTypes: [],
   margins: { bottomPx: 96, leftPx: 96, rightPx: 96, topPx: 96 },
   page: { heightPx: 1123, preset: 'a4', widthPx: 794 },

--- a/packages/pagination/src/lib/__tests__/BasePaginationPlugin.spec.ts
+++ b/packages/pagination/src/lib/__tests__/BasePaginationPlugin.spec.ts
@@ -11,6 +11,23 @@ function editorWithPagination() {
 }
 
 describe('BasePaginationPlugin', () => {
+  it('enables pagination by default', () => {
+    const editor = editorWithPagination();
+
+    expect(editor.getOptions(BasePaginationPlugin).enabled).toBe(true);
+  });
+
+  it('can be disabled via options', () => {
+    const editor = createSlateEditor({
+      plugins: [
+        BasePaginationPlugin.configure({ options: { enabled: false } }),
+      ],
+      value: [{ children: [{ text: 'hello' }], type: 'p' }],
+    });
+
+    expect(editor.getOptions(BasePaginationPlugin).enabled).toBe(false);
+  });
+
   it('invalidates the layout registry on a content edit', () => {
     const editor = editorWithPagination();
     getLayoutRegistry(editor).dirty = false; // simulate a fresh build

--- a/packages/pagination/src/react/PaginationPlugin.tsx
+++ b/packages/pagination/src/react/PaginationPlugin.tsx
@@ -66,10 +66,11 @@ const labelStyle: React.CSSProperties = {
  */
 const PaginationBreakLines: EditableSiblingComponent = () => {
   const editor = useEditorRef();
+  const enabled = usePluginOption(PaginationPlugin, 'enabled');
   const breaks = usePluginOption(PaginationPlugin, 'breaks');
 
   const editable = editor.api.toDOMNode(editor);
-  if (!editable || breaks.length === 0) return null;
+  if (!enabled || !editable || breaks.length === 0) return null;
 
   const style = getComputedStyle(editable);
   const padLeft = Number.parseFloat(style.paddingLeft) || 0;
@@ -136,6 +137,7 @@ export const PaginationPlugin = toPlatePlugin(BasePaginationPlugin, {
   render: { afterEditable: PaginationBreakLines },
   useHooks: ({ editor, setOption }) => {
     const [, forceRecompute] = useState(0);
+    const enabled = usePluginOption(PaginationPlugin, 'enabled');
 
     // Recompute when the layout registry is dirty (content edits via the base
     // plugin's apply override; selection-only changes leave it clean). Runs in a
@@ -144,7 +146,11 @@ export const PaginationPlugin = toPlatePlugin(BasePaginationPlugin, {
     // an extra frame later. setOption re-renders the overlay via usePluginOption.
     // (The residual delay on first load is the editor's hydration time: the SSR
     // content is on screen before the client can measure the DOM to place lines.)
+    // Skipped entirely while disabled; toggling `enabled` re-renders here (the
+    // subscribed option above), so re-enabling recomputes from the dirty registry.
     useIsomorphicLayoutEffect(() => {
+      if (!enabled) return;
+
       const registry = getLayoutRegistry(editor);
       if (!registry.dirty && registry.output) return;
 

--- a/packages/pagination/src/react/PaginationPlugin.tsx
+++ b/packages/pagination/src/react/PaginationPlugin.tsx
@@ -178,8 +178,11 @@ export const PaginationPlugin = toPlatePlugin(BasePaginationPlugin, {
 
     // A width change re-wraps text and changes pagination. Invalidate the layout
     // and force a re-render so the dirty-recompute effect re-measures at the new
-    // width and the overlay re-anchors to the new block tops.
+    // width and the overlay re-anchors to the new block tops. Skip entirely while
+    // disabled — no point observing when the overlay isn't rendered.
     useEffect(() => {
+      if (!enabled) return;
+
       const editable = editor.api.toDOMNode(editor);
       if (!editable || typeof ResizeObserver === 'undefined') return;
 
@@ -190,6 +193,6 @@ export const PaginationPlugin = toPlatePlugin(BasePaginationPlugin, {
       observer.observe(editable);
 
       return () => observer.disconnect();
-    }, [editor]);
+    }, [editor, enabled]);
   },
 });


### PR DESCRIPTION
Stacked on `codex/pagination-dogfood-fixes`. Adds a public `enabled` option to `@platejs/pagination` so consumers can turn pagination on/off at runtime.

## Change
- `BasePaginationPlugin` gains `enabled: boolean` (**default `true`**).
- React layer consumes it: the overlay renders nothing and the layout recompute is skipped when `enabled === false`. Toggling re-renders (subscribed option) so re-enabling recomputes from the dirty registry. The document is never mutated either way.
- Toggle at runtime: `editor.setOption(BasePaginationPlugin, 'enabled', next)`.
- Changeset: `minor`.

## TDD
Red→green on the new public contract (base option seam, `createSlateEditor`):
- `enables pagination by default` — watched it fail (`enabled` undefined), then declared the option.
- `can be disabled via options`.

The React overlay/hook gating is thin glue consuming the tested option (the package's React overlay has no unit tests — only pure geometry; no render-test infra, and the testing-strategy skill forbids adding devDeps for it).

## Verification
- Package: build ✓, typecheck ✓, **51/51 tests** ✓, biome clean on changed files.
- Full monorepo `check` not run (its `eslint .` sweep OOMs here; disproportionate for a one-option package change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)