### PR TITLE
Codex/pagination atomic measure

### DIFF
--- a/.changeset/pagination-enabled-option.md
+++ b/.changeset/pagination-enabled-option.md
@@ -1,0 +1,5 @@
+---
+"@platejs/pagination": minor
+---
+
+Add an `enabled` option (default `true`) to toggle pagination at runtime. When `false`, the React layer skips layout recompute and renders no page-break overlay; the document is never affected either way. Toggle with `editor.setOption(BasePaginationPlugin, 'enabled', next)`.

--- a/apps/www/src/app/dev/pagination2/__tests__/pagination2.spec.tsx
+++ b/apps/www/src/app/dev/pagination2/__tests__/pagination2.spec.tsx
@@ -1,0 +1,107 @@
+/**
+ * Tests for the pagination2 dev demo page and view component.
+ *
+ * The PaginationView component relies on a live Plate editor with DOM
+ * measurement (PaginationPlugin), so heavy dependencies are mocked out. The
+ * tests verify the component's rendering contract and DOM structure.
+ */
+import * as React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, mock } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Mock out the heavy editor + pagination deps before importing the component.
+// ---------------------------------------------------------------------------
+
+// Stub PaginationPlugin so no real DOM measurement pipeline runs.
+mock.module('@platejs/pagination/react', () => ({
+  PaginationPlugin: { key: 'pagination' },
+}));
+
+// BasicNodesKit is just an array of plugins — stub it as empty.
+mock.module(
+  '@/registry/components/editor/plugins/basic-nodes-kit',
+  () => ({
+    BasicNodesKit: [],
+  })
+);
+
+// Stub the Plate editor hook so it returns a minimal editor-shaped object.
+const fakeEditor = { children: [], operations: [], selection: null };
+mock.module('platejs/react', () => ({
+  Plate: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="plate-root">{children}</div>
+  ),
+  PlateContent: (props: React.HTMLAttributes<HTMLDivElement>) => (
+    <div data-testid="plate-content" {...props} />
+  ),
+  usePlateEditor: () => fakeEditor,
+}));
+
+// Now import the module under test (after mocks are registered).
+import { PaginationView } from '../pagination2-view';
+
+// ---------------------------------------------------------------------------
+// page.tsx — static export contract
+// ---------------------------------------------------------------------------
+
+describe('pagination2 page.tsx', () => {
+  it('exports dynamic = "force-dynamic" (prevents SSR of DOM-measurement component)', async () => {
+    // Import dynamically after mocks are in place.
+    const pageModule = await import('../page');
+    expect((pageModule as { dynamic?: string }).dynamic).toBe('force-dynamic');
+  });
+
+  it('renders PaginationView as the default export', async () => {
+    const pageModule = await import('../page');
+    const Page =
+      (pageModule as { default?: React.ComponentType }).default ?? null;
+    expect(Page).not.toBeNull();
+    if (Page) {
+      const { container } = render(<Page />);
+      // The desk wrapper must be present.
+      expect(container.querySelector('[data-testid="pagination-desk"]')).not.toBeNull();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PaginationView — DOM structure
+// ---------------------------------------------------------------------------
+
+describe('PaginationView', () => {
+  it('renders without throwing', () => {
+    expect(() => render(<PaginationView />)).not.toThrow();
+  });
+
+  it('renders the outer desk container with the correct data-testid', () => {
+    render(<PaginationView />);
+    expect(screen.getByTestId('pagination-desk')).toBeDefined();
+  });
+
+  it('renders the inner page-stack container with the correct data-testid', () => {
+    render(<PaginationView />);
+    expect(screen.getByTestId('pagination-stack')).toBeDefined();
+  });
+
+  it('the page-stack is a child of the desk', () => {
+    render(<PaginationView />);
+    const desk = screen.getByTestId('pagination-desk');
+    const stack = screen.getByTestId('pagination-stack');
+    expect(desk.contains(stack)).toBe(true);
+  });
+
+  it('applies A4 width (794px) to the page-stack wrapper', () => {
+    render(<PaginationView />);
+    const stack = screen.getByTestId('pagination-stack');
+    // The inline style sets width: 794 (A4 @ 96dpi).
+    expect((stack as HTMLElement).style.width).toBe('794px');
+  });
+
+  it('applies 1in (96px) padding to the page-stack wrapper', () => {
+    render(<PaginationView />);
+    const stack = screen.getByTestId('pagination-stack');
+    expect((stack as HTMLElement).style.padding).toBe('96px');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "g:release:next": "pnpm build && pnpm changeset publish --tag next",
     "g:typecheck": "pnpm g:build && turbo --filter \"./packages/**\" typecheck --only",
     "g:typecheck:all": "(pnpm build || pnpm build) && turbo typecheck --only",
+    "nuke": "find . \\( -name node_modules -o -name dist -o -name .turbo -o -name .open-next -o -name .opennext -o -name .next \\) -type d -prune -print -exec rm -rf {} +",
     "gen:package": "pnpm exec plop --plopfile tooling/scripts/plop/plopfile.cjs package",
     "lint": "biome check . && eslint",
     "lint:fix": "biome check . --fix",

--- a/packages/pagination/src/layout/__tests__/compose.spec.ts
+++ b/packages/pagination/src/layout/__tests__/compose.spec.ts
@@ -138,4 +138,80 @@ describe('composeLayout (place-whole / option C)', () => {
     expect(out.mapping.pageOfBlock(0)).toBe(0);
     expect(out.mapping.pageOfBlock(1)).toBe(1);
   });
+
+  it('accumulates currentY using flowHeightPx so y offsets are flow-based', () => {
+    // Three blocks each with flowHeightPx=200 (text 100, spacing 100).
+    // All fit on one page (3×200=600 < 931). y offsets should advance by 200.
+    nextId = 0;
+    const out = composeLayout(
+      snap(
+        block(100, { flowHeightPx: 200, path: [0] }),
+        block(100, { flowHeightPx: 200, path: [1] }),
+        block(100, { flowHeightPx: 200, path: [2] })
+      ),
+      INPUT
+    );
+    expect(out.pages).toHaveLength(1);
+    const frags = out.pages[0].frames[0].fragments;
+    expect(frags.map((f) => f.y)).toEqual([0, 200, 400]);
+  });
+
+  it('produces consecutive page indices on a 3-page layout', () => {
+    // Three large blocks, each needing its own page.
+    nextId = 0;
+    const out = composeLayout(
+      snap(
+        block(900, { path: [0] }),
+        block(900, { path: [1] }),
+        block(900, { path: [2] })
+      ),
+      INPUT
+    );
+    expect(out.pages).toHaveLength(3);
+    expect(out.pages.map((p) => p.index)).toEqual([0, 1, 2]);
+    expect(out.metrics).toEqual({ pages: 3, blocks: 3 });
+  });
+
+  it('does not set breakReason on blocks that are not the first on a new page', () => {
+    // Two blocks fit page 0. Third overflows to page 1.
+    nextId = 0;
+    const out = composeLayout(
+      snap(
+        block(400, { path: [0] }),
+        block(400, { path: [1] }),
+        block(400, { path: [2] })
+      ),
+      INPUT
+    );
+    // Second block on page 0 has no breakReason (same page continuation).
+    expect(out.pages[0].frames[0].fragments[1].breakReason).toBeUndefined();
+    // First block on page 1 has breakReason (moved to a new page).
+    expect(out.pages[1].frames[0].fragments[0].breakReason).toBe(
+      'block_overflow'
+    );
+  });
+
+  it('places a block at y=0 when it is the first on a fresh page after overflow', () => {
+    nextId = 0;
+    const out = composeLayout(
+      snap(block(900, { path: [0] }), block(100, { path: [1] })),
+      INPUT
+    );
+    expect(out.pages).toHaveLength(2);
+    const p2frag = out.pages[1].frames[0].fragments[0];
+    expect(p2frag.y).toBe(0);
+  });
+
+  it('places an oversized block at y=0 on the page it starts on', () => {
+    nextId = 0;
+    const out = composeLayout(snap(block(5000, { path: [0] })), INPUT);
+    expect(out.pages[0].frames[0].fragments[0].y).toBe(0);
+  });
+
+  it('a block exactly equal to frame height fits without triggering overflow', () => {
+    // frameHeight = 931. A 931px block must fit on the current page.
+    nextId = 0;
+    const out = composeLayout(snap(block(931, { path: [0] })), INPUT);
+    expect(out.pages).toHaveLength(1);
+  });
 });

--- a/packages/pagination/src/layout/__tests__/continuous.spec.ts
+++ b/packages/pagination/src/layout/__tests__/continuous.spec.ts
@@ -49,4 +49,40 @@ describe('getContinuousBreaks', () => {
     const layout = composeLayout(snap(block(100, [0])), INPUT);
     expect(getContinuousBreaks(layout)).toEqual([]);
   });
+
+  it('produces 2 breaks for 3 pages', () => {
+    // Each 900px block exceeds 931/2=465 remaining after the previous, so they
+    // each go to their own page.
+    const layout = composeLayout(
+      snap(block(900, [0]), block(900, [1]), block(900, [2])),
+      INPUT
+    );
+    const breaks = getContinuousBreaks(layout);
+    expect(breaks).toHaveLength(2);
+    expect(breaks[0]).toEqual({ blockIndex: 1, lineStart: 0 });
+    expect(breaks[1]).toEqual({ blockIndex: 2, lineStart: 0 });
+  });
+
+  it('lineStart is 0 for whole-block boundaries (place-whole mode)', () => {
+    // In place-whole mode, every fragment starts at lineStart=0 (no mid-block
+    // split), so every break's lineStart must be 0.
+    const layout = composeLayout(
+      snap(block(700, [0]), block(700, [1])),
+      INPUT
+    );
+    const breaks = getContinuousBreaks(layout);
+    expect(breaks.every((b) => b.lineStart === 0)).toBe(true);
+  });
+
+  it('getContinuousBreakYs sums fragment heights across frames correctly', () => {
+    // Page 0 contains a 700px block; page 1 contains two 200px blocks.
+    // Total page-0 contribution = 700.
+    const layout = composeLayout(
+      snap(block(700, [0]), block(200, [1]), block(200, [2])),
+      INPUT
+    );
+    const ys = getContinuousBreakYs(layout);
+    // Only one interior boundary; cumulative after page 0 = 700.
+    expect(ys).toEqual([700]);
+  });
 });

--- a/packages/pagination/src/layout/__tests__/snapshot.spec.ts
+++ b/packages/pagination/src/layout/__tests__/snapshot.spec.ts
@@ -66,4 +66,76 @@ describe('buildSnapshot', () => {
     expect(snap.blocks[0].breakBefore).toBeUndefined();
     expect(snap.blocks[1].breakBefore).toBe(true);
   });
+
+  it('returns an empty blocks array for an empty value', () => {
+    const snap = buildSnapshot([], {});
+    expect(snap.blocks).toHaveLength(0);
+  });
+
+  it('collects text from deeply nested children', () => {
+    const snap = buildSnapshot(
+      [
+        {
+          children: [
+            {
+              children: [
+                { children: [{ text: 'deep' }], type: 'span' },
+              ],
+              type: 'inner',
+            },
+          ],
+          type: 'p',
+        },
+      ],
+      {}
+    );
+    expect(snap.blocks[0].text).toBe('deep');
+  });
+
+  it('treats a node with no children and no text property as empty string text', () => {
+    const snap = buildSnapshot([{ type: 'hr' }], {});
+    expect(snap.blocks[0].text).toBe('');
+  });
+
+  it('falls back to content-based id when node.id is an empty string', () => {
+    // An empty-string id has length 0, so stableId must not use it.
+    const snap = buildSnapshot([p('hello', { id: '' })], {});
+    expect(snap.blocks[0].id).not.toBe('');
+    expect(snap.blocks[0].id).toMatch(/^p#/);
+  });
+
+  it('includes the node type in the hash-based id prefix', () => {
+    const snapH1 = buildSnapshot(
+      [{ children: [{ text: 'hello' }], type: 'h1' }],
+      {}
+    );
+    const snapP = buildSnapshot(
+      [{ children: [{ text: 'hello' }], type: 'p' }],
+      {}
+    );
+    // Different type prefix ensures ids differ even when text content is identical.
+    expect(snapH1.blocks[0].id).not.toBe(snapP.blocks[0].id);
+  });
+
+  it('assigns consecutive 0-based paths to all top-level blocks', () => {
+    const snap = buildSnapshot([p('a'), p('b'), p('c'), p('d')], {});
+    expect(snap.blocks.map((b) => b.path)).toEqual([[0], [1], [2], [3]]);
+  });
+
+  it('concatenates text from multiple inline children', () => {
+    const snap = buildSnapshot(
+      [
+        {
+          children: [
+            { text: 'Hello ' },
+            { bold: true, text: 'bold' },
+            { text: ' world' },
+          ],
+          type: 'p',
+        },
+      ],
+      {}
+    );
+    expect(snap.blocks[0].text).toBe('Hello bold world');
+  });
 });

--- a/packages/pagination/src/lib/BasePaginationPlugin.ts
+++ b/packages/pagination/src/lib/BasePaginationPlugin.ts
@@ -20,6 +20,15 @@ import { invalidateLayoutRegistry, shouldInvalidateLayout } from './registry';
 export type PaginationViewMode = 'continuous' | 'paged';
 
 export type PaginationOptions = {
+  /**
+   * Whether pagination is active. When `false`, the React layer skips layout
+   * recompute and renders no page-break overlay, leaving the editor untouched;
+   * the document is never mutated either way. Toggle at runtime with
+   * `editor.setOption(BasePaginationPlugin, 'enabled', next)`.
+   *
+   * @default true
+   */
+  enabled: boolean;
   page: PageSpec;
   margins: PageMargins;
   policies: LayoutPolicies;
@@ -36,6 +45,7 @@ export type PaginationConfig = PluginConfig<'pagination', PaginationOptions>;
 // (cheapest, fully native edit surface — paged is the high-fidelity opt-in).
 const DEFAULT_OPTIONS: PaginationOptions = {
   atomicTypes: [],
+  enabled: true,
   keepWithNextTypes: [],
   margins: { bottomPx: 96, leftPx: 96, rightPx: 96, topPx: 96 },
   page: { heightPx: 1123, preset: 'a4', widthPx: 794 },

--- a/packages/pagination/src/lib/__tests__/BasePaginationPlugin.spec.ts
+++ b/packages/pagination/src/lib/__tests__/BasePaginationPlugin.spec.ts
@@ -11,6 +11,23 @@ function editorWithPagination() {
 }
 
 describe('BasePaginationPlugin', () => {
+  it('enables pagination by default', () => {
+    const editor = editorWithPagination();
+
+    expect(editor.getOptions(BasePaginationPlugin).enabled).toBe(true);
+  });
+
+  it('can be disabled via options', () => {
+    const editor = createSlateEditor({
+      plugins: [
+        BasePaginationPlugin.configure({ options: { enabled: false } }),
+      ],
+      value: [{ children: [{ text: 'hello' }], type: 'p' }],
+    });
+
+    expect(editor.getOptions(BasePaginationPlugin).enabled).toBe(false);
+  });
+
   it('invalidates the layout registry on a content edit', () => {
     const editor = editorWithPagination();
     getLayoutRegistry(editor).dirty = false; // simulate a fresh build

--- a/packages/pagination/src/lib/__tests__/BasePaginationPlugin.spec.ts
+++ b/packages/pagination/src/lib/__tests__/BasePaginationPlugin.spec.ts
@@ -57,4 +57,68 @@ describe('BasePaginationPlugin', () => {
 
     expect(getLayoutRegistry(editor).dirty).toBe(false);
   });
+
+  it('has the plugin key "pagination"', () => {
+    expect(BasePaginationPlugin.key).toBe('pagination');
+  });
+
+  it('defaults to A4 page spec (794×1123 px at 96dpi)', () => {
+    const editor = editorWithPagination();
+    const { page } = editor.getOptions(BasePaginationPlugin);
+    expect(page.widthPx).toBe(794);
+    expect(page.heightPx).toBe(1123);
+    expect(page.preset).toBe('a4');
+  });
+
+  it('defaults to 1in (96px) margins on all sides', () => {
+    const editor = editorWithPagination();
+    const { margins } = editor.getOptions(BasePaginationPlugin);
+    expect(margins.topPx).toBe(96);
+    expect(margins.rightPx).toBe(96);
+    expect(margins.bottomPx).toBe(96);
+    expect(margins.leftPx).toBe(96);
+  });
+
+  it('defaults atomicTypes to an empty array', () => {
+    const editor = editorWithPagination();
+    expect(editor.getOptions(BasePaginationPlugin).atomicTypes).toEqual([]);
+  });
+
+  it('defaults keepWithNextTypes to an empty array', () => {
+    const editor = editorWithPagination();
+    expect(editor.getOptions(BasePaginationPlugin).keepWithNextTypes).toEqual(
+      []
+    );
+  });
+
+  it('defaults viewMode to "continuous"', () => {
+    const editor = editorWithPagination();
+    expect(editor.getOptions(BasePaginationPlugin).viewMode).toBe('continuous');
+  });
+
+  it('marks the registry dirty on remove_node operations', () => {
+    const editor = editorWithPagination();
+    getLayoutRegistry(editor).dirty = false;
+
+    editor.tf.apply({
+      node: { children: [{ text: 'hello' }], type: 'p' },
+      path: [0],
+      type: 'remove_node',
+    });
+
+    expect(getLayoutRegistry(editor).dirty).toBe(true);
+  });
+
+  it('marks the registry dirty on insert_node operations', () => {
+    const editor = editorWithPagination();
+    getLayoutRegistry(editor).dirty = false;
+
+    editor.tf.apply({
+      node: { children: [{ text: 'new' }], type: 'p' },
+      path: [1],
+      type: 'insert_node',
+    });
+
+    expect(getLayoutRegistry(editor).dirty).toBe(true);
+  });
 });

--- a/packages/pagination/src/lib/__tests__/registry.spec.ts
+++ b/packages/pagination/src/lib/__tests__/registry.spec.ts
@@ -53,4 +53,46 @@ describe('layout registry', () => {
     }
     expect(shouldInvalidateLayout({ type: 'set_selection' })).toBe(false);
   });
+
+  it('two editors have independent registry entries', () => {
+    const editorA = createSlateEditor();
+    const editorB = createSlateEditor();
+
+    const entryA = getLayoutRegistry(editorA);
+    const entryB = getLayoutRegistry(editorB);
+
+    // They must be different object references.
+    expect(entryA).not.toBe(entryB);
+
+    // Invalidating A does not affect B.
+    entryA.dirty = false;
+    entryB.dirty = false;
+    invalidateLayoutRegistry(editorA);
+    expect(getLayoutRegistry(editorA).dirty).toBe(true);
+    expect(getLayoutRegistry(editorB).dirty).toBe(false);
+  });
+
+  it('measureCache is a Map present in every fresh entry', () => {
+    const editor = createSlateEditor();
+    const entry = getLayoutRegistry(editor);
+    expect(entry.measureCache).toBeInstanceOf(Map);
+  });
+
+  it('measureCache survives invalidation (same Map reference)', () => {
+    const editor = createSlateEditor();
+    const cacheRef = getLayoutRegistry(editor).measureCache;
+    invalidateLayoutRegistry(editor);
+    // Invalidation marks dirty + clears output, but should not replace the Map.
+    expect(getLayoutRegistry(editor).measureCache).toBe(cacheRef);
+  });
+
+  it('ensureLayout returns null output before first build', () => {
+    const editor = createSlateEditor();
+    expect(getLayoutRegistry(editor).output).toBeNull();
+  });
+
+  it('shouldInvalidateLayout returns false for unknown operation type', () => {
+    // An unknown/future op type is not a content change and must not invalidate.
+    expect(shouldInvalidateLayout({ type: 'unknown_op' })).toBe(false);
+  });
 });

--- a/packages/pagination/src/measure/__tests__/measure.spec.ts
+++ b/packages/pagination/src/measure/__tests__/measure.spec.ts
@@ -92,6 +92,32 @@ describe('measureSnapshot', () => {
     });
   });
 
+  it('packs by pretext heightPx + box spacing when no rendered footprint', () => {
+    const measure = () => ({ heightPx: 100, lineHeightPx: 20, boxSpacingPx: 24 });
+    const out = measureSnapshot(snap(ub('a')), measure, { widthPx: 600 });
+    expect(out.blocks[0].flowHeightPx).toBe(124); // 100 + 24
+  });
+
+  it('packs atomic blocks by renderedHeightPx, keeping line mapping on pretext height', () => {
+    // An image/table: pretext sees ~2 lines of caption text (40px) but the block
+    // renders 300px tall. Packing must use the rendered footprint; line mapping
+    // (heightPx/lineCount) stays pretext-derived.
+    const measure = () => ({
+      boxSpacingPx: 16,
+      heightPx: 40,
+      lineHeightPx: 20,
+      renderedHeightPx: 300,
+    });
+    const out = measureSnapshot(snap(ub('img', { splittable: false })), measure, {
+      widthPx: 600,
+    });
+    expect(out.blocks[0]).toMatchObject({
+      flowHeightPx: 316, // renderedHeightPx (300) + boxSpacing (16)
+      heightPx: 40, // pretext text height — unchanged
+      lineCount: 2, // derived from pretext height, not the rendered footprint
+    });
+  });
+
   it('falls back to a default line when measurement returns null', () => {
     const measure = (): BlockMetrics | null => null;
     const out = measureSnapshot(snap(ub('a')), measure, {

--- a/packages/pagination/src/measure/__tests__/measure.spec.ts
+++ b/packages/pagination/src/measure/__tests__/measure.spec.ts
@@ -130,4 +130,70 @@ describe('measureSnapshot', () => {
       lineCount: 1,
     });
   });
+
+  it('does NOT set flowHeightPx for a plain text block with no box spacing', () => {
+    // A block with only heightPx/lineHeightPx and no boxSpacingPx or
+    // renderedHeightPx must leave flowHeightPx absent so compose falls back to
+    // heightPx, keeping block-level line mapping correct.
+    const measure = () => ({ heightPx: 80, lineHeightPx: 20 });
+    const out = measureSnapshot(snap(ub('a')), measure, { widthPx: 600 });
+    expect(out.blocks[0].flowHeightPx).toBeUndefined();
+  });
+
+  it('sets flowHeightPx when renderedHeightPx is 0 (zero-height atomic)', () => {
+    // renderedHeightPx=0 is explicitly present, so flowHeightPx must be set.
+    const measure = () => ({
+      boxSpacingPx: 8,
+      heightPx: 0,
+      lineHeightPx: 20,
+      renderedHeightPx: 0,
+    });
+    const out = measureSnapshot(snap(ub('void', { splittable: false })), measure, {
+      widthPx: 600,
+    });
+    // 0 (rendered) + 8 (box) = 8
+    expect(out.blocks[0].flowHeightPx).toBe(8);
+  });
+
+  it('cache key avoids collision when block id contains the "@" separator character', () => {
+    // If a block id is e.g. "a@600" and another block has id "a" at width 600,
+    // they would produce the same key "a@600@600" vs "a@600" — only if our key
+    // is "id@width". We verify two distinct ids + same width produce two calls.
+    const cache = new Map();
+    let calls = 0;
+    const measure = () => {
+      calls++;
+      return { heightPx: 100, lineHeightPx: 20 };
+    };
+    // First block id="x@600", second id="x" — different ids, same width.
+    measureSnapshot(
+      snap(ub('x@600'), ub('x')),
+      measure,
+      { cache, widthPx: 600 }
+    );
+    // Both should be measured separately (2 unique cache keys).
+    expect(calls).toBe(2);
+    // Second call with same blocks must be fully cached (0 additional calls).
+    measureSnapshot(
+      snap(ub('x@600'), ub('x')),
+      measure,
+      { cache, widthPx: 600 }
+    );
+    expect(calls).toBe(2);
+  });
+
+  it('uses default 20px fallback lineHeight when fallbackLineHeightPx is not supplied', () => {
+    const measure = (): BlockMetrics | null => null;
+    const out = measureSnapshot(snap(ub('a')), measure, { widthPx: 600 });
+    // Default fallbackLineHeightPx is 20.
+    expect(out.blocks[0].heightPx).toBe(20);
+    expect(out.blocks[0].lineHeightPx).toBe(20);
+  });
+
+  it('lineCount is 1 when lineHeightPx is 0 (guard against division by zero)', () => {
+    // lineHeightPx=0 must not produce NaN or Infinity.
+    const measure = () => ({ heightPx: 100, lineHeightPx: 0 });
+    const out = measureSnapshot(snap(ub('a')), measure, { widthPx: 600 });
+    expect(out.blocks[0].lineCount).toBe(1);
+  });
 });

--- a/packages/pagination/src/measure/__tests__/pretext.spec.ts
+++ b/packages/pagination/src/measure/__tests__/pretext.spec.ts
@@ -66,4 +66,53 @@ describe('measureBlockHeight', () => {
   it('treats empty text as a single line tall', () => {
     expect(measureBlockHeight('', '16px monospace', 100, 20)).toBe(20);
   });
+
+  it('returns a single line height when text fits on one line', () => {
+    // "hi" = 2 chars * 10px = 20px < 100px width → 1 line * 24px = 24.
+    expect(measureBlockHeight('hi', '16px monospace', 100, 24)).toBe(24);
+  });
+
+  it('scales with lineHeightPx (different line height)', () => {
+    // "alpha beta gamma delta" wraps to 3 lines; at lineHeightPx=30 → 90.
+    expect(
+      measureBlockHeight('alpha beta gamma delta', '16px monospace', 100, 30)
+    ).toBe(90);
+  });
+});
+
+describe('measureTextLines — structural guarantees', () => {
+  it('returns at least one line for any non-empty text', () => {
+    const lines = measureTextLines('x', '16px monospace', 1000, 20);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('each line has a non-negative widthPx', () => {
+    const lines = measureTextLines('hello world', '16px monospace', 200, 20);
+    for (const line of lines) {
+      expect(line.widthPx).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('each line carries a text property', () => {
+    const lines = measureTextLines('hello world', '16px monospace', 200, 20);
+    for (const line of lines) {
+      expect(typeof line.text).toBe('string');
+    }
+  });
+
+  it('more lines are produced when the width is narrower', () => {
+    const wideLines = measureTextLines(
+      'alpha beta gamma delta',
+      '16px monospace',
+      1000,
+      20
+    );
+    const narrowLines = measureTextLines(
+      'alpha beta gamma delta',
+      '16px monospace',
+      100,
+      20
+    );
+    expect(narrowLines.length).toBeGreaterThan(wideLines.length);
+  });
 });

--- a/packages/pagination/src/measure/measure.ts
+++ b/packages/pagination/src/measure/measure.ts
@@ -27,6 +27,15 @@ export type BlockMetrics = {
    * flow height for page packing. Optional; defaults to 0 (no spacing).
    */
   boxSpacingPx?: number;
+  /**
+   * Rendered content footprint, in CSS px, for blocks pretext cannot represent
+   * — atomic/non-text blocks (images, tables, embeds) whose height is not their
+   * text-line count. When supplied, it (not {@link heightPx}) is the flow-height
+   * base for page packing. {@link heightPx}/lineCount stay pretext-derived so
+   * line-level mapping is unaffected. Omit for text-flow blocks (pretext owns
+   * their height).
+   */
+  renderedHeightPx?: number;
 };
 
 export type MeasureFn = (block: UnmeasuredBlock) => BlockMetrics | null;
@@ -76,10 +85,15 @@ export function measureSnapshot(
       lineHeightPx,
       path: block.path,
     };
-    // Flow height (for packing) = text height + the block's box spacing. Only set
-    // when the measurer supplied spacing, so the composer falls back cleanly.
+    // Flow height (for packing) = base height + the block's box spacing. The base
+    // is the rendered footprint when the measurer supplied one (atomic/non-text
+    // blocks pretext can't represent), else the pretext text height. heightPx /
+    // lineCount stay pretext-derived so line-level mapping is unaffected.
     const boxSpacingPx = metrics?.boxSpacingPx ?? 0;
-    if (boxSpacingPx > 0) measured.flowHeightPx = heightPx + boxSpacingPx;
+    const flowBase = metrics?.renderedHeightPx ?? heightPx;
+    if (metrics?.renderedHeightPx != null || boxSpacingPx > 0) {
+      measured.flowHeightPx = flowBase + boxSpacingPx;
+    }
     if (block.keepWithNext) measured.keepWithNext = true;
     if (block.breakBefore) measured.breakBefore = true;
     if (block.splittable === false) measured.splittable = false;

--- a/packages/pagination/src/react/PaginationPlugin.tsx
+++ b/packages/pagination/src/react/PaginationPlugin.tsx
@@ -66,10 +66,11 @@ const labelStyle: React.CSSProperties = {
  */
 const PaginationBreakLines: EditableSiblingComponent = () => {
   const editor = useEditorRef();
+  const enabled = usePluginOption(PaginationPlugin, 'enabled');
   const breaks = usePluginOption(PaginationPlugin, 'breaks');
 
   const editable = editor.api.toDOMNode(editor);
-  if (!editable || breaks.length === 0) return null;
+  if (!enabled || !editable || breaks.length === 0) return null;
 
   const style = getComputedStyle(editable);
   const padLeft = Number.parseFloat(style.paddingLeft) || 0;
@@ -136,6 +137,7 @@ export const PaginationPlugin = toPlatePlugin(BasePaginationPlugin, {
   render: { afterEditable: PaginationBreakLines },
   useHooks: ({ editor, setOption }) => {
     const [, forceRecompute] = useState(0);
+    const enabled = usePluginOption(PaginationPlugin, 'enabled');
 
     // Recompute when the layout registry is dirty (content edits via the base
     // plugin's apply override; selection-only changes leave it clean). Runs in a
@@ -144,7 +146,11 @@ export const PaginationPlugin = toPlatePlugin(BasePaginationPlugin, {
     // an extra frame later. setOption re-renders the overlay via usePluginOption.
     // (The residual delay on first load is the editor's hydration time: the SSR
     // content is on screen before the client can measure the DOM to place lines.)
+    // Skipped entirely while disabled; toggling `enabled` re-renders here (the
+    // subscribed option above), so re-enabling recomputes from the dirty registry.
     useIsomorphicLayoutEffect(() => {
+      if (!enabled) return;
+
       const registry = getLayoutRegistry(editor);
       if (!registry.dirty && registry.output) return;
 

--- a/packages/pagination/src/react/domMeasure.ts
+++ b/packages/pagination/src/react/domMeasure.ts
@@ -11,11 +11,24 @@
 import type { MeasureFn } from '../measure/measure';
 import { measureBlockHeight } from '../measure/pretext';
 
-/** Direct top-level block elements of an editable, in document order. */
+/**
+ * Top-level block elements of an editable, in document order. A block is
+ * top-level when no other block element is its ancestor within the editable —
+ * so this holds even when plugins (DnD, block selection) wrap each block in
+ * non-slate container divs, where a `:scope >` direct-child match would find
+ * nothing. Nested blocks (list items, table cells, column children) are
+ * excluded by the ancestor check.
+ */
 export function topLevelBlockElements(editable: HTMLElement): HTMLElement[] {
-  return Array.from(
-    editable.querySelectorAll(':scope > [data-slate-node="element"]')
+  const all = Array.from(
+    editable.querySelectorAll('[data-slate-node="element"]')
   ) as HTMLElement[];
+
+  return all.filter((el) => {
+    const parentBlock = el.parentElement?.closest('[data-slate-node="element"]');
+
+    return !parentBlock || !editable.contains(parentBlock);
+  });
 }
 
 function resolveLineHeight(style: CSSStyleDeclaration): number {
@@ -71,6 +84,13 @@ function verticalBoxSpacing(style: CSSStyleDeclaration): number {
   );
 }
 
+/** Top + bottom margins only — the flow spacing around a measured box. */
+function verticalMargins(style: CSSStyleDeclaration): number {
+  const px = (v: string) => Number.parseFloat(v) || 0;
+
+  return px(style.marginTop) + px(style.marginBottom);
+}
+
 /**
  * Build a {@link MeasureFn} that resolves the block's font + content width from
  * the live editable, then derives height from the number of lines pretext wraps
@@ -85,15 +105,30 @@ export function createDomMeasure(editable: HTMLElement): MeasureFn {
 
     const style = getComputedStyle(dom);
     const lineHeightPx = resolveLineHeight(style);
+    const heightPx = measureBlockHeight(
+      block.text,
+      resolveFont(style),
+      contentWidth(dom, style),
+      lineHeightPx
+    );
+
+    // Atomic/non-text blocks (images, tables, embeds) are placed whole and have
+    // no text flow for pretext to shape — their footprint is the rendered box,
+    // not a text-line count. Pack by that rendered height; spacing is margins
+    // only (the rect already includes padding + border). Pretext still owns
+    // text-flow blocks below (line-accurate height + full box spacing).
+    if (block.splittable === false) {
+      return {
+        boxSpacingPx: verticalMargins(style),
+        heightPx,
+        lineHeightPx,
+        renderedHeightPx: dom.getBoundingClientRect().height,
+      };
+    }
 
     return {
       boxSpacingPx: verticalBoxSpacing(style),
-      heightPx: measureBlockHeight(
-        block.text,
-        resolveFont(style),
-        contentWidth(dom, style),
-        lineHeightPx
-      ),
+      heightPx,
       lineHeightPx,
     };
   };

--- a/templates/plate-playground-template/src/app/dev/pagination2/pagination2-view.tsx
+++ b/templates/plate-playground-template/src/app/dev/pagination2/pagination2-view.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import * as React from 'react';
-
 import { PaginationPlugin } from '@platejs/pagination/react';
-import { type Value } from 'platejs';
+import type { Value } from 'platejs';
 import { Plate, PlateContent, usePlateEditor } from 'platejs/react';
 
 import { BasicNodesKit } from '@/components/editor/plugins/basic-nodes-kit';

--- a/templates/plate-playground-template/src/components/editor/editor-kit.tsx
+++ b/templates/plate-playground-template/src/components/editor/editor-kit.tsx
@@ -32,6 +32,7 @@ import { MarkdownKit } from '@/components/editor/plugins/markdown-kit';
 import { MathKit } from '@/components/editor/plugins/math-kit';
 import { MediaKit } from '@/components/editor/plugins/media-kit';
 import { MentionKit } from '@/components/editor/plugins/mention-kit';
+import { PaginationKit } from '@/components/editor/plugins/pagination-kit';
 import { SlashKit } from '@/components/editor/plugins/slash-kit';
 import { SuggestionKit } from '@/components/editor/plugins/suggestion-kit';
 import { TableKit } from '@/components/editor/plugins/table-kit';
@@ -64,6 +65,9 @@ export const EditorKit = [
   ...ListKit,
   ...AlignKit,
   ...LineHeightKit,
+
+  // Layout
+  ...PaginationKit,
 
   // Collaboration
   ...DiscussionKit,

--- a/templates/plate-playground-template/src/components/editor/plugins/pagination-kit.tsx
+++ b/templates/plate-playground-template/src/components/editor/plugins/pagination-kit.tsx
@@ -1,10 +1,34 @@
 'use client';
 
 import { PaginationPlugin } from '@platejs/pagination/react';
+import { KEYS } from 'platejs';
 
 // Advisory continuous-view page-break overlay. Starts disabled; the
 // PaginationToolbarButton flips `enabled` at runtime via editor.setOption.
 // The overlay is pointer-events:none and never mutates the document.
+//
+// atomicTypes: non-text blocks placed whole. Pretext measures text-flow blocks
+// (paragraphs, headings) line-accurately; these blocks have no text flow to
+// shape, so the engine packs them by their rendered footprint instead. Without
+// this, images/tables/etc. measure as ~one line and the document collapses to a
+// single page (no break lines).
 export const PaginationKit = [
-  PaginationPlugin.configure({ options: { enabled: false } }),
+  PaginationPlugin.configure({
+    options: {
+      atomicTypes: [
+        KEYS.table,
+        KEYS.img,
+        KEYS.video,
+        KEYS.audio,
+        KEYS.file,
+        KEYS.codeBlock,
+        KEYS.toc,
+        KEYS.hr,
+        KEYS.mediaEmbed,
+        KEYS.columnGroup,
+        KEYS.equation,
+      ],
+      enabled: false,
+    },
+  }),
 ];

--- a/templates/plate-playground-template/src/components/editor/plugins/pagination-kit.tsx
+++ b/templates/plate-playground-template/src/components/editor/plugins/pagination-kit.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { PaginationPlugin } from '@platejs/pagination/react';
+
+// Advisory continuous-view page-break overlay. Starts disabled; the
+// PaginationToolbarButton flips `enabled` at runtime via editor.setOption.
+// The overlay is pointer-events:none and never mutates the document.
+export const PaginationKit = [
+  PaginationPlugin.configure({ options: { enabled: false } }),
+];

--- a/templates/plate-playground-template/src/components/ui/fixed-toolbar-buttons.tsx
+++ b/templates/plate-playground-template/src/components/ui/fixed-toolbar-buttons.tsx
@@ -40,6 +40,7 @@ import { MarkToolbarButton } from './mark-toolbar-button';
 import { MediaToolbarButton } from './media-toolbar-button';
 import { ModeToolbarButton } from './mode-toolbar-button';
 import { MoreToolbarButton } from './more-toolbar-button';
+import { PaginationToolbarButton } from './pagination-toolbar-button';
 import { TableToolbarButton } from './table-toolbar-button';
 import { ToggleToolbarButton } from './toggle-toolbar-button';
 import { ToolbarGroup } from './toolbar';
@@ -123,6 +124,7 @@ export function FixedToolbarButtons() {
             <BulletedListToolbarButton />
             <TodoListToolbarButton />
             <ToggleToolbarButton />
+            <PaginationToolbarButton />
           </ToolbarGroup>
 
           <ToolbarGroup>

--- a/templates/plate-playground-template/src/components/ui/pagination-toolbar-button.tsx
+++ b/templates/plate-playground-template/src/components/ui/pagination-toolbar-button.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { PaginationPlugin } from '@platejs/pagination/react';
+import { SeparatorHorizontalIcon } from 'lucide-react';
+import { useEditorRef, usePluginOption } from 'platejs/react';
+import type * as React from 'react';
+
+import { ToolbarButton } from './toolbar';
+
+export function PaginationToolbarButton(
+  props: React.ComponentProps<typeof ToolbarButton>
+) {
+  const editor = useEditorRef();
+  const enabled = usePluginOption(PaginationPlugin, 'enabled');
+
+  return (
+    <ToolbarButton
+      {...props}
+      onClick={() => editor.setOption(PaginationPlugin, 'enabled', !enabled)}
+      pressed={enabled}
+      tooltip="Page breaks"
+    >
+      <SeparatorHorizontalIcon />
+    </ToolbarButton>
+  );
+}


### PR DESCRIPTION
**Checklist**

- [x] `pnpm typecheck`
- [x] `pnpm lint:fix`
- [x] `bun test`
- [x] `pnpm brl`
- [x] `pnpm changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- pnpm brl: Required if adding, moving or removing a file in a package.
- pnpm changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pagination can now be toggled on/off at runtime (enabled by default).
  * Added toolbar button for quick pagination toggling.
  * Enhanced pagination support for non-text content (images, tables, code blocks).

* **Improvements**
  * Disabling pagination skips layout recomputation and page-break rendering for better performance.
  * Improved measurement accuracy for atomic block elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cicero-im/plate/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->