### PR TITLE
fix(pagination): cache topLevelBlockElements + fix changeset language [review fixes for #434]

### DIFF
--- a/.changeset/pagination-enabled-option.md
+++ b/.changeset/pagination-enabled-option.md
@@ -2,4 +2,4 @@
 "@platejs/pagination": minor
 ---
 
-Add an `enabled` option (default `true`) to toggle pagination at runtime. When `false`, the React layer skips layout recompute and renders no page-break overlay; the document is never affected either way. Toggle with `editor.setOption(BasePaginationPlugin, 'enabled', next)`.
+The `enabled` option (default `true`) controls whether pagination is active at runtime. When `false`, the React layer skips layout recompute and renders no page-break overlay; the document is never affected. Toggle with `editor.setOption(BasePaginationPlugin, 'enabled', next)`.

--- a/packages/pagination/src/react/domMeasure.ts
+++ b/packages/pagination/src/react/domMeasure.ts
@@ -99,8 +99,12 @@ function verticalMargins(style: CSSStyleDeclaration): number {
  * Re-queries on each call so it reflects edits.
  */
 export function createDomMeasure(editable: HTMLElement): MeasureFn {
+  // Cache once per recompute — topLevelBlockElements queries the DOM and filters
+  // all descendants; calling it per-block would be O(N²) for an N-block document.
+  const blocks = topLevelBlockElements(editable);
+
   return (block) => {
-    const dom = topLevelBlockElements(editable)[block.path[0]];
+    const dom = blocks[block.path[0]];
     if (!dom) return null;
 
     const style = getComputedStyle(dom);


### PR DESCRIPTION
Review fixes for #434 (two `safe_auto` findings from ce-review).

## Changes

**`packages/pagination/src/react/domMeasure.ts`**

`createDomMeasure` was calling `topLevelBlockElements(editable)` inside the `MeasureFn` closure — once per block per recompute. For N blocks that's N querySelectorAll passes + N filter loops = O(N²) total DOM work. Hoisted the call to the outer `createDomMeasure` scope so it runs once per recompute.

**`.changeset/pagination-enabled-option.md`**

Changeset body used changelog-style language ("Add an `enabled` option"). AGENTS.md prohibits changelog-style; docs must document current state only. Rewrote to present-tense reference.

## Residual findings (for #434 author)

See full review comment on #434. Key items requiring author decision:

- `enabled: boolean` is non-optional in `PaginationOptions` — likely needs `enabled?: boolean` + semver bump reassessment
- Template files bypass CI-control rule — needs explicit authorization in PR body
- `measureCache` not cleared on re-enable after DOM-only changes while disabled
- `topLevelBlockElements` refactor lacks unit test for the DnD-wrapper case

https://claude.ai/code/session_016Wodda9zsyQ9krUCZq6QxY

---
_Generated by [Claude Code](https://claude.ai/code/session_016Wodda9zsyQ9krUCZq6QxY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified pagination `enabled` option behavior: when disabled, pagination remains inactive with no page-break overlays rendered.

* **Performance**
  * Optimized DOM element caching in pagination for improved measurement efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cicero-im/plate/pull/436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->